### PR TITLE
Smallest reminder time can now be set to 1 minute

### DIFF
--- a/data/preferences.ui
+++ b/data/preferences.ui
@@ -764,7 +764,7 @@
     </child>
   </object>
   <object class="GtkAdjustment" id="adjustment1">
-    <property name="lower">5</property>
+    <property name="lower">1</property>
     <property name="upper">121</property>
     <property name="value">5</property>
     <property name="step_increment">1</property>


### PR DESCRIPTION
Hi hamster maintainers,

Thanks for the great tool!

I like to have a frequent reminder of my current activity, every 2 minutes. Unfortunately the preferences pane let me set a reminder inteval of minimum 5 minutes.

I changed the minimum value for the reminder to 1 minute (was 5 minutes)

I would be very pleased if you could include this in the next release.

Best regards,
Chris lutje Spelberg
