### PR TITLE
fixing "global name 'wnck' is not defined"

### DIFF
--- a/src/hamster/today.py
+++ b/src/hamster/today.py
@@ -23,6 +23,7 @@ import logging
 import datetime as dt
 
 import gtk, gobject
+import wnck
 import glib
 import dbus, dbus.service, dbus.mainloop.glib
 import locale


### PR DESCRIPTION
Hi,

As I not a python dev' I m not sure if I did right, but that fix the problem related to "wnck missing".

Regards,
