### PR TITLE
Updates in DBus interface of GTG

### DIFF
--- a/src/hamster/external.py
+++ b/src/hamster/external.py
@@ -58,7 +58,7 @@ class ActivitiesSource(gobject.GObject):
 
             tasks = []
             try:
-                tasks = conn.get_tasks()
+                tasks = conn.GetTasks()
             except dbus.exceptions.DBusException:  #TODO too lame to figure out how to connect to the disconnect signal
                 self.__gtg_connection = None
                 return self.get_activities(query) # reconnect
@@ -77,12 +77,12 @@ class ActivitiesSource(gobject.GObject):
 
     def __get_gtg_connection(self):
         bus = dbus.SessionBus()
-        if self.__gtg_connection and bus.name_has_owner("org.GTG"):
+        if self.__gtg_connection and bus.name_has_owner("org.gnome.GTG"):
             return self.__gtg_connection
 
-        if bus.name_has_owner("org.GTG"):
-            self.__gtg_connection = dbus.Interface(bus.get_object('org.GTG', '/org/GTG'),
-                                                   dbus_interface='org.GTG')
+        if bus.name_has_owner("org.gnome.GTG"):
+            self.__gtg_connection = dbus.Interface(bus.get_object('org.gnome.GTG', '/org/gnome/GTG'),
+                                                   dbus_interface='org.gnome.GTG')
             return self.__gtg_connection
         else:
             return None


### PR DESCRIPTION
Since version 0.2.9, GTG uses a '''better''' DBus name `org.gnome.GTG` instead of `org.GTG`. Exported methods were changed to CamelCase. This patch reflects the changes.
