### PR TITLE
Don't close edit activity if description has focus

### DIFF
--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -297,6 +297,8 @@ class CustomFactController(gtk.Object):
         elif event_key.keyval in (gtk.keysyms.Return, gtk.keysyms.KP_Enter):
             if popups:
                 return False
+            if self.get_widget('description').has_focus():
+                return False
             self.on_save_button_clicked(None)
 
 


### PR DESCRIPTION
- Avoid closing edit activity window when enter in description field
- Allows multi-line messages in description field. Fixes #101

Signed-off-by: Jonathan Brett jonbrett.dev@gmail.com
