### PR TITLE
Make GTK label translatable

### DIFF
--- a/data/stats.ui
+++ b/data/stats.ui
@@ -244,7 +244,7 @@
                     </child>
                     <child>
                       <object class="GtkLabel" id="not_enough_records_label">
-                        <property name="label">Text we say when there is not enough data</property>
+                        <property name="label" translatable="yes">Text we say when there is not enough data</property>
                         <property name="wrap">True</property>
                       </object>
                       <packing>


### PR DESCRIPTION
There is a label in the stats dialogue which is not translatable (fixes #108).

Incidentally, how do you create and compile .po files for hamster?
