### PR TITLE
Do not create new connection for each notification

### DIFF
--- a/data/hamster-time-tracker.schemas.in
+++ b/data/hamster-time-tracker.schemas.in
@@ -55,6 +55,20 @@
             </locale>
         </schema>
         <schema>
+            <key>/schemas/apps/hamster-time-tracker/lock_on_idle</key>
+            <applyto>/apps/hamster-time-tracker/lock_on_idle</applyto>
+            <owner>hamster-time-tracker</owner>
+            <type>bool</type>
+            <default>false</default>
+            <locale name="C">
+                <short>Lock the screen when no activity is set</short>
+                <long>
+                    Also check every notify_interval minutes if no activity
+                    has been started, if true, lock the screen.
+                </long>
+            </locale>
+        </schema>
+        <schema>
             <key>/schemas/apps/hamster-time-tracker/day_start_minutes</key>
             <applyto>/apps/hamster-time-tracker/day_start_minutes</applyto>
             <owner>hamster-time-tracker</owner>

--- a/data/preferences.ui
+++ b/data/preferences.ui
@@ -123,6 +123,28 @@
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkAlignment" id="alignment13">
+                                            <property name="visible">True</property>
+                                            <property name="top_padding">8</property>
+                                            <property name="left_padding">4</property>
+                                            <child>
+                                              <object class="GtkCheckButton" id="lock_on_idle">
+                                                <property name="label" translatable="yes">Lock the screen when no activity is set</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="use_underline">True</property>
+                                                <property name="draw_indicator">True</property>
+                                                <signal name="toggled" handler="on_lock_on_idle_toggled" swapped="no"/>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+
                                       </object>
                                     </child>
                                   </object>

--- a/src/hamster/configuration.py
+++ b/src/hamster/configuration.py
@@ -167,6 +167,7 @@ class GConfStore(gobject.GObject, Singleton):
         'enable_timeout'              :   False,       # Should hamster stop tracking on idle
         'stop_on_shutdown'            :   False,       # Should hamster stop tracking on shutdown
         'notify_on_idle'              :   False,       # Remind also if no activity is set
+        'lock_on_idle'                :   False,       # Lock the screen if no activity is set
         'notify_interval'             :   27,          # Remind of current activity every X minutes
         'day_start_minutes'           :   5 * 60 + 30, # At what time does the day start (5:30AM)
         'overview_window_box'         :   [],          # X, Y, W, H

--- a/src/hamster/lib/desktop.py
+++ b/src/hamster/lib/desktop.py
@@ -39,6 +39,7 @@ class DesktopIntegrations(object):
 
         self.conf_enable_timeout = conf.get("enable_timeout")
         self.conf_notify_on_idle = conf.get("notify_on_idle")
+        self.conf_lock_on_idle = conf.get("lock_on_idle")
         self.conf_notify_interval = conf.get("notify_interval")
         conf.connect('conf-changed', self.on_conf_changed)
 
@@ -81,12 +82,24 @@ class DesktopIntegrations(object):
             if duration and duration % interval == 0:
                 message = _(u"Working on %s") % last_activity['name']
                 self.notify_user(message)
+        else:
+            # Determine whether we should notify the user now
+            time_to_notify = (now.minute + now.hour * 60) % interval == 0
 
-        elif self.conf_notify_on_idle:
-            #if we have no last activity, let's just calculate duration from 00:00
-            if (now.minute + now.hour * 60) % interval == 0:
-                self.notify_user(_(u"No activity"))
+            if time_to_notify:
+                if self.conf_lock_on_idle:
+                    self.lock_screen()
+                elif self.conf_notify_on_idle:
+                    self.notify_user(_(u"No activity"))
 
+    def lock_screen(self):
+        if not hasattr(self, "_screensaver_conn"):
+            proxy_for_screensaver = self.bus.get_object('org.freedesktop.ScreenSaver', '/ScreenSaver')
+            interface_screensaver = dbus.Interface(proxy_for_screensaver, 'org.freedesktop.ScreenSaver')
+            self._screensaver_conn = interface_screensaver
+
+        conn = self._screensaver_conn
+        conn.Lock()
 
     def notify_user(self, summary="", details=""):
         if not hasattr(self, "_notification_conn"):

--- a/src/hamster/preferences.py
+++ b/src/hamster/preferences.py
@@ -307,6 +307,9 @@ class PreferencesEditor(gtk.Object):
         self.get_widget("notify_on_idle").set_active(conf.get("notify_on_idle"))
         self.get_widget("notify_on_idle").set_sensitive(conf.get("notify_interval") <=120)
 
+        self.get_widget("lock_on_idle").set_active(conf.get("lock_on_idle"))
+        self.get_widget("lock_on_idle").set_sensitive(conf.get("notify_interval") <=120)
+
         self.get_widget("workspace_tracking_name").set_active("name" in conf.get("workspace_tracking"))
         self.get_widget("workspace_tracking_memory").set_active("memory" in conf.get("workspace_tracking"))
 
@@ -732,6 +735,9 @@ class PreferencesEditor(gtk.Object):
     def on_notify_on_idle_toggled(self, checkbox):
         conf.set("notify_on_idle", checkbox.get_active())
 
+    def on_lock_on_idle_toggled(self, checkbox):
+        conf.set("lock_on_idle", checkbox.get_active())
+
     def on_notify_interval_format_value(self, slider, value):
         if value <=120:
             # notify interval slider value label
@@ -748,6 +754,7 @@ class PreferencesEditor(gtk.Object):
         value = int(scale.get_value())
         conf.set("notify_interval", value)
         self.get_widget("notify_on_idle").set_sensitive(value <= 120)
+        self.get_widget("lock_on_idle").set_sensitive(value <= 120)
 
     def on_day_start_changed(self, widget):
         day_start = self.day_start.get_time()


### PR DESCRIPTION
This typo caused creation of new dbus connection every time a
notification was sent.
