### PR TITLE
corrected function name: set_tags_autocomplete -> update_autocomplete_tags

### DIFF
--- a/src/hamster/storage.py
+++ b/src/hamster/storage.py
@@ -158,7 +158,7 @@ class Storage(object):
             self.tags_changed()
         return tags
 
-    def set_tags_autocomplete(self, tags):
+    def update_autocomplete_tags(self, tags):
         changes = self.__update_autocomplete_tags(tags)
         if changes:
             self.tags_changed()


### PR DESCRIPTION
renamed function for storing tag autocomplete preferences
fixes #80
