### PR TITLE
Update report_template.html

### DIFF
--- a/data/report_template.html
+++ b/data/report_template.html
@@ -352,7 +352,7 @@
 
     <div id="date_chart"></div>
 
-    <a id="activity_log_link" href="#">Show activity log</a>
+    <a id="activity_log_link" href="javascript:activity_log_link()">Show activity log</a>
     <div id="activity_log">
         <h2>$activity_log_title</h2>
         <table>


### PR DESCRIPTION
"Show activity log" link causes a blank html page to open with the single word 'false'. 
This has been mentioned in at least one website, for example, 
http://projecthamster.wordpress.com/2010/11/08/report-love-something-for-freelancers/
and of course, by myself. 

What should happen? 

On click of the link, the "Activity Log" part of the report visibility should toggle (visible or not visible depending on current state).