### PR TITLE
Don't remove the same source twice

### DIFF
--- a/src/hamster/lib/graphics.py
+++ b/src/hamster/lib/graphics.py
@@ -1734,7 +1734,7 @@ class Scene(Parent, gtk.DrawingArea):
 
         self._blank_cursor = gdk.Cursor(gdk.CursorType.BLANK_CURSOR)
 
-        self.__previous_mouse_signal_time = None
+        self.__previous_mouse_signal_time = 0
 
 
         #: Miminum distance in pixels for a drag to occur
@@ -1996,8 +1996,9 @@ class Scene(Parent, gtk.DrawingArea):
 
     """ mouse events """
     def __on_mouse_move(self, scene, event):
-        if self.__last_mouse_move:
+        if self.__last_mouse_move > 0:
             gobject.source_remove(self.__last_mouse_move)
+            self.__last_mouse_move = 0
 
         self.mouse_x, self.mouse_y = event.x, event.y
 


### PR DESCRIPTION
When running hamster-windows-service from terminal and moving the mouse over the overview there's a lot of noise about attempts to remove a not existing source. This resets the id of removed sources.
