### PR TITLE
if no activity or tags input, don't proceed to start tracking

### DIFF
--- a/src/hamster/today.py
+++ b/src/hamster/today.py
@@ -442,6 +442,9 @@ class DailyView(object):
     def on_switch_activity_clicked(self, widget):
         activity, temporary = self.new_name.get_value()
 
+        if not activity:
+            return
+
         fact = stuff.Fact(activity,
                           tags = self.new_tags.get_text().decode("utf8", "replace"))
         if not fact.activity:


### PR DESCRIPTION
Following crash happens when user starts tracking without entering Activity, Tags, or both.

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/hamster/today.py", line 451, in on_switch_activity_clicked
    tags = self.new_tags.get_text().decode("utf8", "replace"))
  File "/usr/lib/python2.7/site-packages/hamster/lib/__init__.py", line 52, in __init__
    input_parts = activity.strip().split(" ")
AttributeError: 'NoneType' object has no attribute 'strip'
```
