### PR TITLE
fix crash when show About dialog

### DIFF
--- a/src/hamster/about.py
+++ b/src/hamster/about.py
@@ -20,6 +20,7 @@
 
 from os.path import join
 from configuration import runtime
+import gobject
 import gtk
 
 def on_email(about, mail):
@@ -31,8 +32,15 @@ def on_url(about, link):
 gtk.about_dialog_set_email_hook(on_email)
 gtk.about_dialog_set_url_hook(on_url)
 
-class About(object):
+
+class About(gtk.Object):
+    __gsignals__ = {
+        "on-close": (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, ()),
+    }
+
     def __init__(self, parent = None):
+        gtk.Object.__init__(self)
+
         about = gtk.AboutDialog()
         self.window = about
         infos = {
@@ -60,5 +68,9 @@ class About(object):
 
         about.set_logo_icon_name("hamster-applet")
 
-        about.connect("response", lambda self, *args: self.destroy())
+        about.connect("response", self.on_about_response)
         about.show_all()
+
+    def on_about_response(self, dialog, response_id, *args):
+        dialog.destroy()
+        self.emit('on-close')


### PR DESCRIPTION
fix crash when show About dialog

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/hamster/today.py", line 340, in on_menu_about_activate
    dialogs.about.show(self.window)
  File "/usr/lib/python2.7/site-packages/hamster/configuration.py", line 111, in show
    self.dialog_close_handlers[dialog] = dialog.connect("on-close", self.on_close_window)
AttributeError: 'About' object has no attribute 'connect'
```
