### PR TITLE
Specify Python version.

### DIFF
--- a/src/hamster-cli
+++ b/src/hamster-cli
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # - coding: utf-8 -
 
 # Copyright (C) 2010 Matías Ribecky <matias at mribecky.com.ar>


### PR DESCRIPTION
On some distros, python is linked to python3 instead of python2 as assumed by the script.
