### PR TITLE
Fixed export unicode error

### DIFF
--- a/src/hamster/reports.py
+++ b/src/hamster/reports.py
@@ -44,6 +44,10 @@ from calendar import timegm
 
 from StringIO import StringIO
 
+# fix encoding on export
+reload(sys)
+sys.setdefaultencoding("utf-8")
+
 def simple(facts, start_date, end_date, format, path = None):
     facts = copy.deepcopy(facts) # dont want to do anything bad to the input
     report_path = stuff.locale_from_utf8(path)


### PR DESCRIPTION
Fixed encoding error when eporting data.  

_Error_

>  File "/usr/local/lib/python2.7/dist-packages/hamster/reports.py", line 162, in **init**
>    self.csv_writer.writerow([h for h in headers])
> UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 7: ordinal not in range(128)
