### PR TITLE
Fixes mnemonic accelerator key conflict of "Tracking" and "Start Tracking" in today.ui

### DIFF
--- a/data/today.ui
+++ b/data/today.ui
@@ -405,7 +405,7 @@
                             </child>
                             <child>
                               <object class="GtkButton" id="start_tracking">
-                                <property name="label" translatable="yes">Start _Tracking</property>
+                                <property name="label" translatable="yes">_Start Tracking</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
                                 <property name="no_show_all">True</property>

--- a/po/af.po
+++ b/po/af.po
@@ -392,8 +392,8 @@ msgid "S_witch"
 msgstr "_Wissel"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "Begin _taak"
+msgid "_Start Tracking"
+msgstr "_Begin taak"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/ar.po
+++ b/po/ar.po
@@ -379,7 +379,7 @@ msgid "S_witch"
 msgstr "ب_دّل"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "ا_بدأ التتبع"
 
 #: ../data/today.ui.h:12

--- a/po/as.po
+++ b/po/as.po
@@ -385,8 +385,8 @@ msgid "S_witch"
 msgstr "কাম পৰিবৰ্তন (_w)"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "অনুসৰণ আৰম্ভ কৰক (_T)"
+msgid "_Start Tracking"
+msgstr "অনুসৰণ আৰম্ভ কৰক (_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/be.po
+++ b/po/be.po
@@ -390,7 +390,7 @@ msgid "S_witch"
 msgstr "Пера_ключыць"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Пачаць адсочванне"
 
 #: ../data/today.ui.h:12

--- a/po/bg.po
+++ b/po/bg.po
@@ -395,7 +395,7 @@ msgid "S_witch"
 msgstr "_Смяна"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Начало на отчитането"
 
 #: ../data/today.ui.h:12

--- a/po/bn.po
+++ b/po/bn.po
@@ -399,8 +399,8 @@ msgid "S_witch"
 msgstr "পরিবর্তন (_w)"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "অনুসরণ বন্ধ করা হবে (_T)"
+msgid "_Start Tracking"
+msgstr "অনুসরণ বন্ধ করা হবে (_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -399,7 +399,7 @@ msgstr "কর্ম পরিবর্তন"
 
 #: ../data/today.ui.h:11
 #, fuzzy
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "অনুসরণ বন্ধ করা হবে (_S)"
 
 #: ../data/today.ui.h:12

--- a/po/ca.po
+++ b/po/ca.po
@@ -393,7 +393,7 @@ msgid "S_witch"
 msgstr "_Canvia"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "C_omença a comptar"
 
 #: ../data/today.ui.h:12

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -392,7 +392,7 @@ msgid "S_witch"
 msgstr "_Canvia"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "C_omença a comptar"
 
 #: ../data/today.ui.h:12

--- a/po/cs.po
+++ b/po/cs.po
@@ -391,7 +391,7 @@ msgid "S_witch"
 msgstr "Př_epnout"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Spustit sledování"
 
 #: ../data/today.ui.h:12

--- a/po/da.po
+++ b/po/da.po
@@ -394,7 +394,7 @@ msgid "S_witch"
 msgstr "S_kift"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "Start _måling"
 
 #: ../data/today.ui.h:12

--- a/po/de.po
+++ b/po/de.po
@@ -402,8 +402,8 @@ msgid "S_witch"
 msgstr "_Wechseln"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "Erfassung s_tarten"
+msgid "_Start Tracking"
+msgstr "Erfassung _starten"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/el.po
+++ b/po/el.po
@@ -398,7 +398,7 @@ msgid "S_witch"
 msgstr "Α_λλαγή"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "Εκκίνηση _καταγραφής"
 
 #: ../data/today.ui.h:12

--- a/po/en@shaw.po
+++ b/po/en@shaw.po
@@ -392,8 +392,8 @@ msgid "S_witch"
 msgstr "_𐑕𐑢𐑦𐑗"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "𐑕𐑑𐑸𐑑 _𐑑𐑮𐑨𐑒𐑦𐑙"
+msgid "_Start Tracking"
+msgstr "_𐑕𐑑𐑸𐑑 𐑑𐑮𐑨𐑒𐑦𐑙"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -387,8 +387,8 @@ msgid "S_witch"
 msgstr "S_witch"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "Start _Tracking"
+msgid "_Start Tracking"
+msgstr "_Start Tracking"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -387,8 +387,8 @@ msgid "S_witch"
 msgstr "S_witch"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "Start _Tracking"
+msgid "_Start Tracking"
+msgstr "_Start Tracking"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/eo.po
+++ b/po/eo.po
@@ -389,7 +389,7 @@ msgid "S_witch"
 msgstr "Ŝ_anĝi"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "K_omenci ŝanĝospuradon"
 
 #: ../data/today.ui.h:12

--- a/po/es.po
+++ b/po/es.po
@@ -393,7 +393,7 @@ msgid "S_witch"
 msgstr "Ca_mbiar"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Iniciar el seguimiento"
 
 #: ../data/today.ui.h:12

--- a/po/et.po
+++ b/po/et.po
@@ -391,7 +391,7 @@ msgid "S_witch"
 msgstr "_Vaheta"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Alusta jälgimist"
 
 #: ../data/today.ui.h:12

--- a/po/eu.po
+++ b/po/eu.po
@@ -390,7 +390,7 @@ msgid "S_witch"
 msgstr "_Aldatu"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Hasi jarraipena"
 
 #: ../data/today.ui.h:12

--- a/po/fi.po
+++ b/po/fi.po
@@ -398,7 +398,7 @@ msgid "S_witch"
 msgstr "_Vaihda"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Aloita seuranta"
 
 #: ../data/today.ui.h:12

--- a/po/fr.po
+++ b/po/fr.po
@@ -406,7 +406,7 @@ msgid "S_witch"
 msgstr "C_hanger"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Commencer le suivi"
 
 #: ../data/today.ui.h:12

--- a/po/gl.po
+++ b/po/gl.po
@@ -392,7 +392,7 @@ msgid "S_witch"
 msgstr "C_ambiar"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "Comezar o _seguimento"
 
 #: ../data/today.ui.h:12

--- a/po/gu.po
+++ b/po/gu.po
@@ -383,8 +383,8 @@ msgid "S_witch"
 msgstr "બદલો (_w)"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "શોધવાનું શરૂ કરો (_T)"
+msgid "_Start Tracking"
+msgstr "શોધવાનું શરૂ કરો (_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/he.po
+++ b/po/he.po
@@ -389,7 +389,7 @@ msgid "S_witch"
 msgstr "ה_חלפה"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "ה_תחלת מעקב"
 
 #: ../data/today.ui.h:12

--- a/po/hi.po
+++ b/po/hi.po
@@ -404,7 +404,7 @@ msgstr "स्विच (_w)"
 
 #: ../data/today.ui.h:11
 #, fuzzy
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "ट्रैंकिंग रोकें (_S)"
 
 #: ../data/today.ui.h:12

--- a/po/hu.po
+++ b/po/hu.po
@@ -395,7 +395,7 @@ msgid "S_witch"
 msgstr "_Váltás"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "Nyilvántartás _megkezdése"
 
 #: ../data/today.ui.h:12

--- a/po/id.po
+++ b/po/id.po
@@ -391,7 +391,7 @@ msgid "S_witch"
 msgstr "_Tukar"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Mulai Melacak"
 
 #: ../data/today.ui.h:12

--- a/po/it.po
+++ b/po/it.po
@@ -412,7 +412,7 @@ msgstr "Ca_mbia"
 
 # (ndt) pulsante
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "A_vvia conteggio"
 
 #: ../data/today.ui.h:12

--- a/po/ja.po
+++ b/po/ja.po
@@ -391,8 +391,8 @@ msgid "S_witch"
 msgstr "切り替え(_W)"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "記録の開始(_T)"
+msgid "_Start Tracking"
+msgstr "記録の開始(_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/kn.po
+++ b/po/kn.po
@@ -396,7 +396,7 @@ msgstr "ಬದಲಾಯಿಸು"
 
 #: ../data/today.ui.h:11
 #, fuzzy
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "ಟ್ರ್ಯಾಕಿಂಗ್ ಅನ್ನು ನಿಲ್ಲಿಸು(_S)"
 
 #: ../data/today.ui.h:12

--- a/po/ko.po
+++ b/po/ko.po
@@ -391,8 +391,8 @@ msgid "S_witch"
 msgstr "전환(_W)"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "추적 시작(_T)"
+msgid "_Start Tracking"
+msgstr "추적 시작(_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/ku.po
+++ b/po/ku.po
@@ -396,7 +396,7 @@ msgstr ""
 
 #: ../data/today.ui.h:11
 #, fuzzy
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "Şopandinê Bi_sekinîne"
 
 #: ../data/today.ui.h:12

--- a/po/lt.po
+++ b/po/lt.po
@@ -387,7 +387,7 @@ msgid "S_witch"
 msgstr "Pe_rjungti"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Pradėti sekimą"
 
 #: ../data/today.ui.h:12

--- a/po/lv.po
+++ b/po/lv.po
@@ -389,8 +389,8 @@ msgid "S_witch"
 msgstr "Pār_slēgties"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "Sāk_t uzskaiti"
+msgid "_Start Tracking"
+msgstr "_Sākt uzskaiti"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/mai.po
+++ b/po/mai.po
@@ -385,7 +385,7 @@ msgid "S_witch"
 msgstr "बदलू"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr ""
 
 #: ../data/today.ui.h:12

--- a/po/mk.po
+++ b/po/mk.po
@@ -393,7 +393,7 @@ msgid "S_witch"
 msgstr "П_ремини"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Почни со следење"
 
 #: ../data/today.ui.h:12

--- a/po/ml.po
+++ b/po/ml.po
@@ -399,7 +399,7 @@ msgstr "മാറുക"
 
 #: ../data/today.ui.h:11
 #, fuzzy
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_നിരീക്ഷണം നിര്‍ത്തുക"
 
 #: ../data/today.ui.h:12

--- a/po/mr.po
+++ b/po/mr.po
@@ -397,7 +397,7 @@ msgstr "बदलवा"
 
 #: ../data/today.ui.h:11
 #, fuzzy
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "मार्गनिर्देशन थांबवा (_S)"
 
 #: ../data/today.ui.h:12

--- a/po/nb.po
+++ b/po/nb.po
@@ -378,8 +378,8 @@ msgid "S_witch"
 msgstr "B_ytt"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "Star_t sporing"
+msgid "_Start Tracking"
+msgstr "_Start sporing"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/nl.po
+++ b/po/nl.po
@@ -413,8 +413,8 @@ msgstr "Wisselen"
 
 #: ../data/today.ui.h:11
 #, fuzzy
-msgid "Start _Tracking"
-msgstr "Registratie _stoppen"
+msgid "_Start Tracking"
+msgstr "Registratie _start"
 
 #: ../data/today.ui.h:12
 #, fuzzy

--- a/po/or.po
+++ b/po/or.po
@@ -389,8 +389,8 @@ msgid "S_witch"
 msgstr "ପରିବର୍ତ୍ତନ କରନ୍ତୁ (_w)"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "ଅନୁସରଣ ଆରମ୍ଭ କରନ୍ତୁ (_T)"
+msgid "_Start Tracking"
+msgstr "ଅନୁସରଣ ଆରମ୍ଭ କରନ୍ତୁ (_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/pa.po
+++ b/po/pa.po
@@ -384,8 +384,8 @@ msgid "S_witch"
 msgstr "ਬਦਲੋ(_w)"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "ਟਰੈਕਿੰਗ ਰੋਕੋ(_T)"
+msgid "_Start Tracking"
+msgstr "ਟਰੈਕਿੰਗ ਰੋਕੋ(_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/pl.po
+++ b/po/pl.po
@@ -401,7 +401,7 @@ msgid "S_witch"
 msgstr "_Przełącz"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Rozpocznij śledzenie"
 
 #: ../data/today.ui.h:12

--- a/po/pt.po
+++ b/po/pt.po
@@ -392,7 +392,7 @@ msgid "S_witch"
 msgstr "_Alterar"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "Iniciar o _Registo"
 
 #: ../data/today.ui.h:12

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -397,7 +397,7 @@ msgid "S_witch"
 msgstr "_Trocar"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "Iniciar re_gistro"
 
 #: ../data/today.ui.h:12

--- a/po/ro.po
+++ b/po/ro.po
@@ -392,8 +392,8 @@ msgid "S_witch"
 msgstr "Com_utare"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "Porneș_te pontarea"
+msgid "_Start Tracking"
+msgstr "Porne_ște pontarea"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/ru.po
+++ b/po/ru.po
@@ -393,7 +393,7 @@ msgid "S_witch"
 msgstr "_Сменить"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "Начать _учёт"
 
 #: ../data/today.ui.h:12

--- a/po/si.po
+++ b/po/si.po
@@ -404,7 +404,7 @@ msgstr ""
 
 #: ../data/today.ui.h:11
 #, fuzzy
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "Tracking නවතන්න (_S)"
 
 #: ../data/today.ui.h:12

--- a/po/sl.po
+++ b/po/sl.po
@@ -391,7 +391,7 @@ msgid "S_witch"
 msgstr "_Preklopi"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "Začni s _sledenjem"
 
 #: ../data/today.ui.h:12

--- a/po/sq.po
+++ b/po/sq.po
@@ -411,7 +411,7 @@ msgstr ""
 
 #: ../data/today.ui.h:11
 #, fuzzy
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Ndalo numërimin"
 
 #: ../data/today.ui.h:12

--- a/po/sr.po
+++ b/po/sr.po
@@ -394,7 +394,7 @@ msgid "S_witch"
 msgstr "Пре_баци"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "З_апочни праћење"
 
 #: ../data/today.ui.h:12

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -394,7 +394,7 @@ msgid "S_witch"
 msgstr "Pre_baci"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "Z_apočni praćenje"
 
 #: ../data/today.ui.h:12

--- a/po/sv.po
+++ b/po/sv.po
@@ -389,8 +389,8 @@ msgid "S_witch"
 msgstr "Vä_xla"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "Starta _tidmätning"
+msgid "_Start Tracking"
+msgstr "_Starta tidmätning"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/ta.po
+++ b/po/ta.po
@@ -396,8 +396,8 @@ msgid "S_witch"
 msgstr "(_w)மாற்றி"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "தொடர்வதை துவக்கவும் (_T)"
+msgid "_Start Tracking"
+msgstr "தொடர்வதை துவக்கவும் (_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/te.po
+++ b/po/te.po
@@ -393,8 +393,8 @@ msgid "S_witch"
 msgstr "మారు(_w)"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "జాడపట్టుట మొదలుపెట్టు (_T)"
+msgid "_Start Tracking"
+msgstr "జాడపట్టుట మొదలుపెట్టు (_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/th.po
+++ b/po/th.po
@@ -406,7 +406,7 @@ msgstr "สลับ"
 
 #: ../data/today.ui.h:11
 #, fuzzy
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_หยุดติดตาม"
 
 #: ../data/today.ui.h:12

--- a/po/tr.po
+++ b/po/tr.po
@@ -384,8 +384,8 @@ msgid "S_witch"
 msgstr "Ge_çiş Yap"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "_Takibi Başlat"
+msgid "_Start Tracking"
+msgstr "T_akibi Başlat"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/ug.po
+++ b/po/ug.po
@@ -393,8 +393,8 @@ msgid "S_witch"
 msgstr "ئالماشتۇر(_W)"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "ئىزلاشنى باشلا(_T)"
+msgid "_Start Tracking"
+msgstr "ئىزلاشنى باشلا(_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/uk.po
+++ b/po/uk.po
@@ -391,7 +391,7 @@ msgid "S_witch"
 msgstr "_Змінити"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "Почати _облік"
 
 #: ../data/today.ui.h:12

--- a/po/vi.po
+++ b/po/vi.po
@@ -407,7 +407,7 @@ msgstr "Chuyển đổi"
 
 #: ../data/today.ui.h:11
 #, fuzzy
-msgid "Start _Tracking"
+msgid "_Start Tracking"
 msgstr "_Dừng theo dõi"
 
 #: ../data/today.ui.h:12

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -386,8 +386,8 @@ msgid "S_witch"
 msgstr "切换(_W)"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "开始跟踪(_T)"
+msgid "_Start Tracking"
+msgstr "开始跟踪(_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -382,8 +382,8 @@ msgid "S_witch"
 msgstr "切換(_W)"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "開始追蹤(_T)"
+msgid "_Start Tracking"
+msgstr "開始追蹤(_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -382,8 +382,8 @@ msgid "S_witch"
 msgstr "切換(_W)"
 
 #: ../data/today.ui.h:11
-msgid "Start _Tracking"
-msgstr "開始追蹤(_T)"
+msgid "_Start Tracking"
+msgstr "開始追蹤(_S)"
 
 #: ../data/today.ui.h:12
 msgid "Start new activity"


### PR DESCRIPTION
Switched the underscore shortcut character of "Start Tracking" from "T" to "S", this no longer conflicts with "Tracking" and allows quick keyboard-only usage of Hamster.

Please check some of the translation files as I think my editor may have re-encoded them, causing them to completely replace one another with git.

Have also fixed a translation error in nl.po

This resolves issue #213