### PR TITLE
In a python3 or mixed environment specifiy the major version to use

### DIFF
--- a/src/hamster-service
+++ b/src/hamster-service
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # nicked off gwibber
 
 from gi.repository import GObject as gobject

--- a/src/hamster-windows-service
+++ b/src/hamster-windows-service
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # nicked off hamster-service
 
 from gi.repository import GObject as gobject


### PR DESCRIPTION
Currently hamster doesn't work in a python3 environment because of these 2 babies.