### PR TITLE
Expand tags field in "Categories and Tags"

### DIFF
--- a/data/preferences.ui
+++ b/data/preferences.ui
@@ -686,7 +686,7 @@
                         </child>
                       </object>
                       <packing>
-                        <property name="expand">False</property>
+                        <property name="expand">True</property>
                         <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>


### PR DESCRIPTION
As per suggestion of @brimlar in issue #206: setting expand to true will make the field to edit tags in the preferences window show up properly.