### PR TITLE
Associate tasks to specific workspaces and follow changes automatically

### DIFF
--- a/src/hamster/lib/desktop.py
+++ b/src/hamster/lib/desktop.py
@@ -33,6 +33,7 @@ class DesktopIntegrations(object):
     def __init__(self, storage):
         self.storage = storage # can't use client as then we get in a dbus loop
         self._last_notification = None
+        self._saved = {}
 
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
         self.bus = dbus.SessionBus()
@@ -108,13 +109,57 @@ class DesktopIntegrations(object):
 
 
     def on_idle_changed(self, event, state):
+        if not self.conf_enable_timeout:
+            if '__paused__' in self._saved:
+                del self._saved['__paused__']
+            return
+        
         # state values: 0 = active, 1 = idle
-        if state == 1 and self.conf_enable_timeout:
+        if state == 1:
             idle_from = self.idle_listener.getIdleFrom()
             idle_from = timegm(idle_from.timetuple())
+            self.save_current('__paused__')
             self.storage.StopTracking(idle_from)
+        elif '__paused__' in self._saved:
+            self.restore('__paused__', delete=True)
 
 
     def on_conf_changed(self, event, key, value):
         if hasattr(self, "conf_%s" % key):
             setattr(self, "conf_%s" % key, value)
+
+
+    def get_current(self):
+        facts = self.storage.get_todays_facts()
+        if facts:
+            last = facts[-1]
+            if not last['end_time']:
+                name = last['name']
+                category = last['category']
+                return name,category
+
+
+    def save_current(self, key):
+        current = self.get_current()
+        if current:
+            self._saved[key] = current
+        elif key in self._saved:
+            del self._saved[key]
+
+
+    def restore(self, key, delete=False):
+        activity,category = None,None
+        if key in self._saved:
+            activity, category = self._saved[key]            
+            if delete:
+                del self._saved[key]
+        
+        if not activity:
+            self.storage.StopTracking(None)
+            return
+        
+        if category:
+            activity = '%s@%s' % (activity,category)
+        
+        self.storage.add_fact( activity, None, None)
+

--- a/src/hamster/workspace.py
+++ b/src/hamster/workspace.py
@@ -1,0 +1,51 @@
+# - coding: utf-8 -
+
+# Copyright (C) 2015 Aurelien Naldi <aurelien.naldi at gmail.com>
+
+# This file is part of Project Hamster.
+
+# Project Hamster is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Project Hamster is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
+
+from gi.repository import GObject as gobject
+from gi.repository import Wnck as wnck
+import dbus
+
+class WnckWatcher(gobject.GObject):
+    """
+    Listen for workspace changes with Wnck and forward them to the desktop integration agent.
+    It handles all wnck-specific parts and forwards standardised signals, based on the screensaver helper.
+    """
+    __gsignals__ = {
+        "workspace-changed": (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT,gobject.TYPE_PYOBJECT))
+    }
+    def __init__(self):
+        gobject.GObject.__init__(self)
+
+        try:
+            self.bus = dbus.SessionBus()
+        except:
+            return 0
+        wnck.Screen.get_default().connect("active-workspace-changed", self.on_workspace_changed)
+
+
+    def on_workspace_changed(self, screen, previous_workspace):
+        try:
+            workspace_id = screen.get_active_workspace().get_number()
+            if previous_workspace:
+                previous_workspace = previous_workspace.get_number()
+        except:
+            return
+        
+        self.emit('workspace-changed', previous_workspace, workspace_id)
+


### PR DESCRIPTION
I added a simple mechanism to save/restore previous tasks and used it to:
* resume tasks which have been interrupted by screen lock
* change the current task upon workspace changes

It still lacks proper setting (and their GUI) but it "works for me" :)