### PR TITLE
Updated README's build instructions to avoid lib import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ RPM-based: `yum install gettext intltool gnome-python2-gconf`
 #### Building
 
 ```bash
-./waf configure build --prefix=/usr/local
+./waf configure build --prefix=/usr
 sudo ./waf install
 ```
 


### PR DESCRIPTION
As shown in #221 targeting prefix /usr/local appears to break library imports on various distros. I don't think any other systems that have already been building to /usr/local would break if they changed to /usr

Distro-specific packages can of course build to whatever dir works for them anyway, too.