### PR TITLE
Update German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -30,7 +30,7 @@ msgstr "Neue Tätigkeit hinzufügen"
 
 #: ../data/edit_activity.ui.h:2 ../data/range_pick.ui.h:5
 msgid "to"
-msgstr "zu"
+msgstr "bis"
 
 #: ../data/edit_activity.ui.h:3
 msgid "in progress"


### PR DESCRIPTION
Replace "zu" with "bis". Results in "10 bis 12" instead of "10 zu 12".
