### PR TITLE
Set can_focus GtkWindow property to avoid pop-under effect

### DIFF
--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -3,7 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkWindow" id="custom_fact_window">
-    <property name="can_focus">False</property>
+    <property name="can_focus">True</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
     <property name="border_width">12</property>
     <property name="title" translatable="yes">Add Earlier Activity</property>

--- a/data/preferences.ui
+++ b/data/preferences.ui
@@ -10,7 +10,7 @@
   </object>
   <object class="GtkTextBuffer" id="autocomplete_tags"/>
   <object class="GtkWindow" id="window">
-    <property name="can_focus">False</property>
+    <property name="can_focus">True</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
     <property name="border_width">12</property>
     <property name="title" translatable="yes">Time Tracker Preferences</property>

--- a/data/stats.ui
+++ b/data/stats.ui
@@ -3,6 +3,7 @@
   <requires lib="gtk+" version="2.16"/>
   <!-- interface-naming-policy project-wide -->
   <object class="GtkWindow" id="stats_window">
+    <property name="can_focus">True</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
     <property name="border_width">10</property>
     <property name="title" translatable="yes">Statistics</property>


### PR DESCRIPTION
This could be the solution for 
https://github.com/projecthamster/unity-indicator/issues/5

I behaved nicely in my minimal testing.
