### PR TITLE
hamster: use gi.require_version for every gi module

### DIFF
--- a/src/hamster-cli
+++ b/src/hamster-cli
@@ -143,6 +143,7 @@ class HamsterClient(object):
             getattr(server, window_name)()
         else:
             print "Running in devel mode"
+            from hamster.lib import gi_versions
             from gi.repository import Gtk as gtk
             from hamster.lib.configuration import dialogs
             getattr(dialogs, window_name).show()

--- a/src/hamster-service
+++ b/src/hamster-service
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2
 # nicked off gwibber
 
+from hamster.lib import gi_versions
 from gi.repository import GObject as gobject
 
 import dbus, dbus.service

--- a/src/hamster-windows-service
+++ b/src/hamster-windows-service
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2
 # nicked off hamster-service
 
+from hamster.lib import gi_versions
 from gi.repository import GObject as gobject
 from gi.repository import GLib as glib
 import dbus, dbus.service

--- a/src/hamster/about.py
+++ b/src/hamster/about.py
@@ -20,6 +20,7 @@
 
 from os.path import join
 from hamster.lib.configuration import runtime
+from .lib import gi_versions
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
 

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -22,6 +22,7 @@
 import datetime as dt
 from calendar import timegm
 import dbus, dbus.mainloop.glib
+from .lib import gi_versions
 from gi.repository import GObject as gobject
 from hamster.lib import Fact
 from hamster.lib import trophies

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
+from .lib import gi_versions
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk

--- a/src/hamster/idle.py
+++ b/src/hamster/idle.py
@@ -24,7 +24,7 @@ import logging
 
 from dbus.lowlevel import Message
 
-gi.require_version('GConf', '2.0')
+from .lib import gi_versions
 from gi.repository import GConf as gconf
 from gi.repository import GObject as gobject
 

--- a/src/hamster/lib/charting.py
+++ b/src/hamster/lib/charting.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
+from . import gi_versions
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 from gi.repository import Pango as pango

--- a/src/hamster/lib/configuration.py
+++ b/src/hamster/lib/configuration.py
@@ -28,6 +28,7 @@ from xdg.BaseDirectory import xdg_data_home
 import logging
 import datetime as dt
 
+from . import gi_versions
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 from gi.repository import GConf as gconf

--- a/src/hamster/lib/desktop.py
+++ b/src/hamster/lib/desktop.py
@@ -20,6 +20,7 @@
 import datetime as dt
 from calendar import timegm
 import logging
+from . import gi_versions
 from gi.repository import GObject as gobject
 
 

--- a/src/hamster/lib/gi_versions.py
+++ b/src/hamster/lib/gi_versions.py
@@ -1,0 +1,9 @@
+import gi
+gi.require_version('GObject', '2.0')
+gi.require_version('GLib', '2.0')
+gi.require_version('GConf', '2.0')
+gi.require_version('Gdk', '3.0')
+gi.require_version('Gtk', '3.0')
+gi.require_version('Pango', '1.0')
+gi.require_version('PangoCairo', '1.0')
+gi.require_version('Gio', '2.0')

--- a/src/hamster/lib/graphics.py
+++ b/src/hamster/lib/graphics.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 import math
 import datetime as dt
 
-
+from . import gi_versions
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
 from gi.repository import GObject as gobject

--- a/src/hamster/lib/layout.py
+++ b/src/hamster/lib/layout.py
@@ -6,6 +6,7 @@
 
 import datetime as dt
 import math
+from . import gi_versions
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
 from gi.repository import GObject as gobject

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -24,7 +24,7 @@
 import gi
 import logging
 
-gi.require_version('Gtk', '3.0')
+from . import gi_versions
 from gi.repository import Gtk as gtk
 from gi.repository import Pango as pango
 

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -25,6 +25,7 @@ import webbrowser
 
 from collections import defaultdict
 
+from .lib import gi_versions
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
 from gi.repository import GObject as gobject

--- a/src/hamster/preferences.py
+++ b/src/hamster/preferences.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
+from .lib import gi_versions
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
 from gi.repository import GObject as gobject

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -38,6 +38,7 @@ import storage
 from shutil import copy as copyfile
 import itertools
 import datetime as dt
+from ..lib import gi_versions
 try:
     from gi.repository import Gio as gio
 except ImportError:

--- a/src/hamster/widgets/__init__.py
+++ b/src/hamster/widgets/__init__.py
@@ -18,6 +18,7 @@
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime as dt
+from ..lib import gi_versions
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
 from gi.repository import Pango as pango

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -22,6 +22,7 @@ import cairo
 import datetime as dt
 import re
 
+from ..lib import gi_versions
 from gi.repository import Gdk as gdk
 from gi.repository import Gtk as gtk
 from gi.repository import GObject as gobject

--- a/src/hamster/widgets/dates.py
+++ b/src/hamster/widgets/dates.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
+from ..lib import gi_versions
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 from gi.repository import Pango as pango

--- a/src/hamster/widgets/dayline.py
+++ b/src/hamster/widgets/dayline.py
@@ -20,6 +20,7 @@
 import time
 import datetime as dt
 
+from ..lib import gi_versions
 from gi.repository import Gtk as gtk
 from gi.repository import GObject as gobject
 from gi.repository import PangoCairo as pangocairo

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -23,6 +23,7 @@ import datetime as dt
 
 from collections import defaultdict
 
+from ..lib import gi_versions
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk

--- a/src/hamster/widgets/reportchooserdialog.py
+++ b/src/hamster/widgets/reportchooserdialog.py
@@ -22,6 +22,7 @@ import pygtk
 pygtk.require('2.0')
 
 import os
+from ..lib import gi_versions
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 from hamster.lib.configuration import conf

--- a/src/hamster/widgets/tags.py
+++ b/src/hamster/widgets/tags.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
+from ..lib import gi_versions
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 from gi.repository import Pango as pango

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -21,6 +21,7 @@ import datetime as dt
 import calendar
 import re
 
+from ..lib import gi_versions
 from gi.repository import Gdk as gdk
 from gi.repository import Gtk as gtk
 from gi.repository import GObject as gobject


### PR DESCRIPTION
This should silence all
"PyGIWarning: XXX was imported without specifying a version first."
log messages.

Users have complained about these warnings repeatedly. This patch bundles all gi version requirements in one place, lib/gi_versions.py, and just imports that were necessary.

FTR: I understand that you're not putting maintenance efforts in this code base any more. However I wanted to share this with you anyway. I've taken ownership of hamster-time-tracker for openSUSE. In this role, I need and want to share all fixes I make for the upstream package with upstream. I'll checkout the new code base at some later time.