### PR TITLE
Fix a divide-by-zero error when rendering bars with zero width

### DIFF
--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -224,7 +224,7 @@ class HorizontalBarChart(graphics.Sprite):
             g.move_to(100 - label_w, y)
             pangocairo.show_layout(context, self.layout)
 
-            w = (self.alloc_w - 110) * value.total_seconds() / self._max.total_seconds()
+            w = self._max.total_seconds() and (self.alloc_w - 110) * value.total_seconds() / self._max.total_seconds()
             w = max(1, int(round(w)))
             g.rectangle(110, y, int(w), int(label_h))
             g.fill("#999")


### PR DESCRIPTION
In the stats view, if there are any zero-width bars to display, there's a ZeroDivisionError, which causes some bizarre rendering glitches. I noticed this when I had an unfinished task at the end of a day against a tag.