### PR TITLE
Added missing dependency for debian systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can use the usually stable `master` or [download stable releases](https://gi
 
 #### Dependencies
 
-Debian-based: `apt-get install gettext intltool python-gconf python-xdg gir1.2-gconf-2.0 python-dbus`
+Debian-based: `apt-get install gettext intltool python-gconf python-xdg gir1.2-gconf-2.0 python-dbus python-gi-cairo`
 
 RPM-based: `yum install gettext intltool gnome-python2-gconf dbus-python`
 


### PR DESCRIPTION
Hamster is unable to run on debian-based systems without the python-gi-cairo package. Added it to the dependency list in README.me.