### PR TITLE
Add calls to gobject-introspection to prevent PyGIWarnings

### DIFF
--- a/src/hamster/lib/configuration.py
+++ b/src/hamster/lib/configuration.py
@@ -28,6 +28,9 @@ from xdg.BaseDirectory import xdg_data_home
 import logging
 import datetime as dt
 
+import gi
+gi.require_version('GConf', '2.0')
+
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 from gi.repository import GConf as gconf

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -25,6 +25,9 @@ import webbrowser
 
 from collections import defaultdict
 
+import gi
+gi.require_version('PangoCairo', '1.0')
+
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
 from gi.repository import GObject as gobject


### PR DESCRIPTION
I was noticing PyGIWarnings being displayed on every call to `hamster`.
```
/usr/local/lib/python2.7/dist-packages/hamster/lib/configuration.py:33: PyGIWarning: GConf was imported without specifying a version first. Use gi.require_version('GConf', '2.0') before import to ensure that the right version gets loaded.
```
````
/usr/local/lib/python2.7/dist-packages/hamster/lib/configuration.py:33: PyGIWarning: GConf was imported without specifying a version first. Use gi.require_version('GConf', '2.0') before import to ensure that the right version gets loaded.
  from gi.repository import GConf as gconf
````

This pull request adds the `gi.require_version()` calls to prevent these warnings.

These warnings are also described in issue https://github.com/projecthamster/hamster/issues/287