### PR TITLE
fixed UnicodeEncodeError in hamster-cli

### DIFF
--- a/src/hamster-cli
+++ b/src/hamster-cli
@@ -283,13 +283,13 @@ class HamsterClient(object):
         facts = self.storage.get_facts(start_time, end_time, search)
 
 
-        headers = {'activity': _("Activity"),
-                   'category': _("Category"),
-                   'tags': _("Tags"),
-                   'description': _("Description"),
-                   'start': _("Start"),
-                   'end': _("End"),
-                   'duration': _("Duration")}
+        headers = {'activity': _("Activity").encode("utf-8"),
+                   'category': _("Category").encode("utf-8"),
+                   'tags': _("Tags").encode("utf-8"),
+                   'description': _("Description").encode("utf-8"),
+                   'start': _("Start").encode("utf-8"),
+                   'end': _("End").encode("utf-8"),
+                   'duration': _("Duration").encode("utf-8")}
 
 
         # print date if it is not the same day


### PR DESCRIPTION
this occured, using the german lang package and the command "hamster list"

Traceback (most recent call last):
  File "/usr/bin/hamster", line 391, in <module>
    getattr(hamster_client, command)(*args)
  File "/usr/bin/hamster", line 254, in list
    self._list(start_time, end_time)
  File "/usr/bin/hamster", line 313, in _list
    print fact_line.format(**headers)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in position 1: ordinal not in range(128)