### PR TITLE
Fix Hamster window toggle on dbus method.

### DIFF
--- a/src/hamster/today.py
+++ b/src/hamster/today.py
@@ -427,7 +427,7 @@ class DailyView(object):
 
 
     def on_toggle_called(self, client):
-        self.window.present()
+        self.toggle_hamster_window()
 
     def on_conf_changed(self, event, key, value):
         if key == "day_start_minutes":


### PR DESCRIPTION
There's a bug in Hamster.

Hamster version: 1.04-3 (from Arch Linux)
Desktop Environment: i3

### Steps reproducing this bug

Run Hamster and close the Hamster window (e.g. by hitting Escape).
Then call DBus method `org.gnome.Hamster.Toggle`:
```bash
dbus-send --session --dest=org.gnome.Hamster --type=method_call --print-reply /org/gnome/Hamster org.gnome.Hamster.Toggle
```

### Expected result

As docstring says:

https://github.com/projecthamster/hamster/blob/a5bda5a59abfaa7bd98dc525e5e0a404598c6bcd/src/hamster-service#L129-L133

So Hamster window should show on the screen.

### Actual result

Hamster prints to the output:
```pytb
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/hamster/today.py", line 430, in on_toggle_called
    self.window.present()
AttributeError: 'NoneType' object has no attribute 'present'
```

So `self.window` is `None`.

### Solution

We should call `self.toggle_hamster_window()` instead of `self.window.present()`