### PR TITLE
Maintainer change for the legacy projecthamster/hamster

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,8 @@
+Whole projecthamster maintainer:
 Eric Goller
 E-mail: projecthamster.20.elbenfreund@spamgourmet.org
 Userid: elbenfreund
+
+legacy projecthamster/hamster subproject maintainer:
+Ederag (edera at gmx.fr)
+Userid: ederag


### PR DESCRIPTION
Thanks to @elbenfreund for [giving write access](https://github.com/projecthamster/hamster-gtk/issues/228#issuecomment-440579659) to keep the legacy [projecthamster/hamster](https://github.com/projecthamster/hamster) alive,
until migration to the `hamster-*` rewrite is recommended.
