### PR TITLE
remove obsolete env line

### DIFF
--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2014 Toms Bauģis <toms.baugis at gmail.com>


### PR DESCRIPTION
`overview.py` contained an obsolete shebang line.
There is no `__main__` inside this file.
