### PR TITLE
also look for still ongoing activities

### DIFF
--- a/src/hamster-cli
+++ b/src/hamster-cli
@@ -213,7 +213,7 @@ class HamsterClient(object):
 
         start_time = start_time or dt.datetime.combine(dt.date.today(), dt.time())
         end_time = end_time or start_time.replace(hour=23, minute=59, second=59)
-        facts = self.storage.get_facts(start_time, end_time)
+        facts = self.storage.get_facts(start_time, end_time, ongoing_days=31)
 
         writer = reports.simple(facts, start_time.date(), end_time.date(), export_format)
 
@@ -279,7 +279,7 @@ class HamsterClient(object):
 
     def _list(self, start_time, end_time, search=""):
         """Print a listing of activities"""
-        facts = self.storage.get_facts(start_time, end_time, search)
+        facts = self.storage.get_facts(start_time, end_time, search, ongoing_days=31)
 
 
         headers = {'activity': _("Activity"),

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -92,7 +92,7 @@ class CustomFactController(gobject.GObject):
         self.validate_fields()
 
     def draw_preview(self, start_time, end_time=None):
-        day_facts = runtime.storage.get_facts(self.date)
+        day_facts = runtime.storage.get_facts(self.date, ongoing_days=31)
         self.dayline.plot(self.date, day_facts, start_time, end_time)
 
 

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -477,8 +477,7 @@ class Overview(Controller):
         search_active = self.header_bar.search_button.get_active()
         search = "" if not search_active else self.filter_entry.get_text()
         search = "%s*" % search if search else "" # search anywhere
-
-        self.facts = self.storage.get_facts(start, end, search_terms=search)
+        self.facts = self.storage.get_facts(start, end, search_terms=search, ongoing_days=31)
         self.fact_tree.set_facts(self.facts)
         self.totals.set_facts(self.facts)
 

--- a/src/hamster/reports.py
+++ b/src/hamster/reports.py
@@ -283,7 +283,7 @@ class HTMLWriter(ReportWriter):
         by_date = dict(by_date)
 
         date_facts = []
-        date = self.start_date
+        date = min(by_date.keys())
         while date <= self.end_date:
             str_date = date.strftime(
                         # date column format for each row in HTML report


### PR DESCRIPTION
Fix issues #152 and #232.

Add the `ongoing_days` keyword argument to `client.get_facts`.
Default to 0 so this should not be breaking.
Overview and command-line use ongoing_days=31 to search for
ongoing activities started in the past month.

Show these ongoing activities in reports too,
to help spot these leftovers.