### PR TITLE
base Fact comparison on main attributes

### DIFF
--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -28,8 +28,9 @@ import datetime as dt
 """
 from hamster import widgets
 from hamster.lib.configuration import runtime, conf, load_ui_file
-from hamster.lib.stuff import datetime_to_hamsterday
+from hamster.lib.stuff import hamster_today
 from hamster.lib import Fact
+
 
 class CustomFactController(gobject.GObject):
     __gsignals__ = {
@@ -64,7 +65,7 @@ class CustomFactController(gobject.GObject):
             self.get_widget("save_button").set_label("gtk-save")
             self.window.set_title(_("Update activity"))
         else:
-            self.date = datetime_to_hamsterday(dt.datetime.now())
+            self.date = hamster_today()
             self.get_widget("delete_button").set_sensitive(False)
             if base_fact:
                 # cloning

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -140,7 +140,11 @@ class Fact(object):
         }
 
     def copy(self, **kwds):
-        """Return an independent copy, with overrides as keyword arguments."""
+        """Return an independent copy, with overrides as keyword arguments.
+
+        By default, only copy user-visible attributes.
+        To also copy the id, use fact.copy(id=fact.id)
+        """
         return Fact(initial_fact=self, **kwds)
 
     @property

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -198,7 +198,16 @@ class Fact(object):
         return "%s %s" % (datetime, name)
 
     def __eq__(self, other):
-        return other and self.id == other.id
+        return (id(self) == id(other)
+                or (isinstance(other, Fact)
+                    and self.activity == other.activity
+                    and self.category == other.category
+                    and self.description == other.description
+                    and self.end_time == other.end_time
+                    and self.start_time == other.start_time
+                    and self.tags == other.tags
+                   )
+                )
 
     def __repr__(self):
         return self.serialized(prepend_date=True)

--- a/src/hamster/lib/graphics.py
+++ b/src/hamster/lib/graphics.py
@@ -1859,7 +1859,7 @@ class Scene(Parent, gtk.DrawingArea):
 
 
     def __setattr__(self, name, val):
-        if self.__dict__.get(name, "hamster_graphics_no_value_really") == val:
+        if self.__dict__.get(name, "hamster_graphics_no_value_really") is val:
             return
 
         if name == '_focus_sprite':

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -58,6 +58,11 @@ def datetime_to_hamsterday(civil_date_time):
     return hamster_date_time.date()
 
 
+def hamster_today():
+    """Return the current hamster day."""
+    return datetime_to_hamsterday(dt.datetime.now())
+
+
 def hamsterday_time_to_datetime(hamsterday, time):
     """Return the civil datetime corresponding to a given hamster day and time.
 

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -66,7 +66,7 @@ class HeaderBar(gtk.HeaderBar):
         gtk.StyleContext.add_class(box.get_style_context(), "linked")
         self.pack_start(box)
 
-        self.range_pick = RangePick(dt.datetime.today()) # TODO - use hamster day
+        self.range_pick = RangePick(stuff.hamster_today())
         self.pack_start(self.range_pick)
 
         self.add_activity_button = gtk.Button()

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -46,6 +46,8 @@ except ImportError:
 
 from hamster.lib import Fact
 from hamster.lib import trophies
+from hamster.lib.stuff import hamster_today
+
 
 class Storage(storage.Storage):
     con = None # Connection will be created on demand
@@ -706,7 +708,7 @@ class Storage(storage.Storage):
             # or current time if fact has happened in last 12 hours
             if fact["end_time"]:
                 fact_end_time = fact["end_time"]
-            elif (dt.datetime.now().date() == fact["start_time"].date()) or \
+            elif (hamster_today() == fact["start_time"].date()) or \
                  (dt.datetime.now() - fact["start_time"]) <= dt.timedelta(hours=12):
                 fact_end_time = dt.datetime.now().replace(microsecond = 0)
             else:

--- a/src/hamster/widgets/dates.py
+++ b/src/hamster/widgets/dates.py
@@ -193,11 +193,12 @@ class RangePick(gtk.ToggleButton):
 
     def on_manual_range_apply_clicked(self, button):
         self.current_range = "manual"
-        cal_date = self.get_widget("start_calendar").get_date()
-        self.start_date = dt.datetime(cal_date[0], cal_date[1] + 1, cal_date[2])
+        # GtkCalendar January is 0, hence the + 1
+        year, month, day = self.get_widget("start_calendar").get_date()
+        self.start_date = dt.date(year, month + 1, day)
 
-        cal_date = self.get_widget("end_calendar").get_date()
-        self.end_date = dt.datetime(cal_date[0], cal_date[1] + 1, cal_date[2])
+        year, month, day = self.get_widget("end_calendar").get_date()
+        self.end_date = dt.date(year, month + 1, day)
 
         # make sure we always have a valid range
         if self.end_date < self.start_date:

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -393,12 +393,11 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         if self.vadjustment:
             self.vadjustment.set_value(0)
 
-        # FIXME: should not mix fact.date (hamster day) and datetime.
         if self.facts:
             start = self.facts[0].date
             end = self.facts[-1].date
         else:
-            start = end = dt.datetime.now()
+            start = end = stuff.hamster_today()
 
         by_date = defaultdict(list)
         for fact in self.facts:

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -254,6 +254,12 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         self.connect("on-double-click", self.on_double_click)
 
 
+    @property
+    def current_fact_index(self):
+        """Current fact index in the self.facts list."""
+        facts_ids = [fact.id for fact in self.facts]
+        return facts_ids.index(self.current_fact.id)
+
     def on_mouse_down(self, scene, event):
         self.grab_focus()
         if self.hover_fact:
@@ -277,7 +283,7 @@ class FactTree(graphics.Scene, gtk.Scrollable):
     def on_key_press(self, scene, event):
         if event.keyval == gdk.KEY_Up:
             if self.current_fact:
-                idx = max(0, self.facts.index(self.current_fact) - 1)
+                idx = max(0, self.current_fact_index - 1)
             else:
                 # enter from below
                 idx = len(self.facts) - 1
@@ -285,7 +291,7 @@ class FactTree(graphics.Scene, gtk.Scrollable):
 
         elif event.keyval == gdk.KEY_Down:
             if self.current_fact:
-                idx = min(len(self.facts) - 1, self.facts.index(self.current_fact) + 1)
+                idx = min(len(self.facts) - 1, self.current_fact_index + 1)
             else:
                 # enter from top
                 idx = 0

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -109,7 +109,36 @@ class TestActivityInputParsing(unittest.TestCase):
         self.assertEqual(fact_copy.activity, "case")
         self.assertEqual(fact_copy.category, "cat")
         self.assertEqual(fact_copy.description, "description")
-        self.assertEqual(set(fact_copy.tags), set(["bäg", "tag"]))
+        self.assertEqual(fact_copy.tags, ["tag", "bäg"])
+
+    def test_comparison(self):
+        fact1 = Fact("12:25-13:25 case@cat, description #tag #bäg")
+        fact2 = fact1.copy()
+        self.assertEqual(fact1, fact2)
+        fact2 = fact1.copy()
+        fact2.activity = "abcd"
+        self.assertNotEqual(fact1, fact2)
+        fact2 = fact1.copy()
+        fact2.category = "abcd"
+        self.assertNotEqual(fact1, fact2)
+        fact2 = fact1.copy()
+        fact2.description = "abcd"
+        self.assertNotEqual(fact1, fact2)
+        import datetime as dt
+        fact2 = fact1.copy()
+        fact2.start_time = dt.datetime.now()
+        self.assertNotEqual(fact1, fact2)
+        fact2 = fact1.copy()
+        fact2.end_time = dt.datetime.now()
+        self.assertNotEqual(fact1, fact2)
+        # wrong order
+        fact2 = fact1.copy()
+        fact2.tags = ["bäg", "tag"]
+        self.assertNotEqual(fact1, fact2)
+        # correct order
+        fact2 = fact1.copy()
+        fact2.tags = ["tag", "bäg"]
+        self.assertEqual(fact1, fact2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Seems to fix issue #381.

The `fact.id` is not modified when the `fact.end_time` changes,
but comparison of facts was based on `fact.id` alone,
and for some reason, this lead python to *not* rebind `self.facts` to the new `facts` after
https://github.com/projecthamster/hamster/blob/843f3638e62beff2f4b0145cdd362bc7b30cb0ee/src/hamster/widgets/facttree.py#L400
=> assigned but not identical. Weird. (further analysis in #381)

Note: `fact.id` is the hamster database id, not the python `id(fact)`.

With this PR, facts comparison is based on the main attributes.
(excluding `id` and `activity_id` attributes that are database implementation details)