### PR TITLE
Improve keyboard handling

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,19 @@
 ===============
+Changes since v2.2.2
+===============
+* Improved keyboard handling:
+  - Ctrl+Space to stop tracking.
+  - Left/Right arrows change date.
+  - Resume: start now a clone of the selected activity.
+    Ctrl-+: clone or fallback to new if none selected.
+            (same as pressing the + button)
+    Ctrl-R: only Resume (clone) an existing fact.
+    Ctrl-N: only new.
+  - Up, down, Home, End, Page-Up, Page-Down, Return
+    work straight from the overview (no need to click).
+  - More info on PR #387.
+
+===============
 Version 2.2.2
 ===============
 * Restore python3 < 3.6 compatibility.

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -479,6 +479,8 @@ class Overview(Controller):
             elif event.keyval == gdk.KEY_r:
                 # Resume/run; clear separation between Ctrl-R and Ctrl-N
                 self.start_new_fact(clone_selected=True, fallback=False)
+            elif event.keyval == gdk.KEY_space:
+                self.storage.stop_tracking()
             elif event.keyval in (gdk.KEY_KP_Add, gdk.KEY_plus):
                 # same as pressing the + icon
                 self.start_new_fact(clone_selected=True, fallback=True)

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -58,11 +58,11 @@ class HeaderBar(gtk.HeaderBar):
         self.set_show_close_button(True)
 
         box = gtk.Box(False)
-        time_back = gtk.Button.new_from_icon_name("go-previous-symbolic", gtk.IconSize.MENU)
-        time_forth = gtk.Button.new_from_icon_name("go-next-symbolic", gtk.IconSize.MENU)
+        self.time_back = gtk.Button.new_from_icon_name("go-previous-symbolic", gtk.IconSize.MENU)
+        self.time_forth = gtk.Button.new_from_icon_name("go-next-symbolic", gtk.IconSize.MENU)
 
-        box.add(time_back)
-        box.add(time_forth)
+        box.add(self.time_back)
+        box.add(self.time_forth)
         gtk.StyleContext.add_class(box.get_style_context(), "linked")
         self.pack_start(box)
 
@@ -93,8 +93,8 @@ class HeaderBar(gtk.HeaderBar):
         self.system_menu.show_all()
 
 
-        time_back.connect("clicked", self.on_time_back_click)
-        time_forth.connect("clicked", self.on_time_forth_click)
+        self.time_back.connect("clicked", self.on_time_back_click)
+        self.time_forth.connect("clicked", self.on_time_forth_click)
         self.connect("button-press-event", self.on_button_press)
 
     def on_button_press(self, bar, event):
@@ -459,6 +459,12 @@ class Overview(Controller):
             # These keys should work even when fact_tree does not have focus
             self.fact_tree.on_key_press(self, event)
             return True  # stop event propagation
+        elif event.keyval == gdk.KEY_Left:
+            self.header_bar.time_back.emit("clicked")
+            return True
+        elif event.keyval == gdk.KEY_Right:
+            self.header_bar.time_forth.emit("clicked")
+            return True
 
         if self.fact_tree.has_focus() or self.totals.has_focus():
             if event.keyval == gdk.KEY_Tab:

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -467,7 +467,13 @@ class Overview(Controller):
             if event.keyval == gdk.KEY_f:
                 self.header_bar.search_button.set_active(True)
             elif event.keyval == gdk.KEY_n:
-                dialogs.edit.show(self)
+                self.start_new_fact(clone_selected=False)
+            elif event.keyval == gdk.KEY_r:
+                # Resume/run; clear separation between Ctrl-R and Ctrl-N
+                self.start_new_fact(clone_selected=True, fallback=False)
+            elif event.keyval in (gdk.KEY_KP_Add, gdk.KEY_plus):
+                # same as pressing the + icon
+                self.start_new_fact(clone_selected=True, fallback=True)
 
         if event.keyval == gdk.KEY_Escape:
             self.close_window()
@@ -501,7 +507,7 @@ class Overview(Controller):
         self.find_facts()
 
     def on_add_activity_clicked(self, button):
-        dialogs.edit.show(self, base_fact=self.fact_tree.current_fact)
+        self.start_new_fact(clone_selected=True, fallback=True)
 
     def on_row_activated(self, tree, day, fact):
         dialogs.edit.show(self, fact_id=fact.id)
@@ -553,6 +559,18 @@ class Overview(Controller):
         self.report_chooser.connect("report-chosen", on_report_chosen)
         self.report_chooser.connect("report-chooser-closed", on_report_chooser_closed)
         self.report_chooser.show(start, end)
+
+    def start_new_fact(self, clone_selected=True, fallback=True):
+        """Start now a new fact.
+        clone_selected (bool): whether to start a clone of currently
+            selected fact or to create a new fact from scratch.
+        fallback (bool): if True, fall back to creating from scratch
+                         in case of no selected fact.
+        """
+        if not clone_selected:
+            dialogs.edit.show(self, base_fact=None)
+        elif self.fact_tree.current_fact or fallback:
+            dialogs.edit.show(self, base_fact=self.fact_tree.current_fact)
 
     def close_window(self):
         self.window.destroy()

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -452,11 +452,13 @@ class Overview(Controller):
                 self.filter_entry.set_text("")
                 self.header_bar.search_button.set_active(False)
                 return True
-            elif event.keyval in (gdk.KEY_Up, gdk.KEY_Down,
-                                  gdk.KEY_Page_Up, gdk.KEY_Page_Down,
-                                  gdk.KEY_Return):
-                self.fact_tree.on_key_press(self, event)
-                return True
+        elif event.keyval in (gdk.KEY_Up, gdk.KEY_Down,
+                              gdk.KEY_Home, gdk.KEY_End,
+                              gdk.KEY_Page_Up, gdk.KEY_Page_Down,
+                              gdk.KEY_Return, gdk.KEY_Delete):
+            # These keys should work even when fact_tree does not have focus
+            self.fact_tree.on_key_press(self, event)
+            return True  # stop event propagation
 
         if self.fact_tree.has_focus() or self.totals.has_focus():
             if event.keyval == gdk.KEY_Tab:

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -298,6 +298,12 @@ class FactTree(graphics.Scene, gtk.Scrollable):
                 idx = 0
             self.set_current_fact(self.facts[idx])
 
+        elif event.keyval == gdk.KEY_Home:
+            self.set_current_fact(self.facts[0])
+
+        elif event.keyval == gdk.KEY_End:
+            self.set_current_fact(self.facts[-1])
+
         elif event.keyval == gdk.KEY_Page_Down:
             self.y += self.height * 0.8
             self.on_scroll()
@@ -305,12 +311,6 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         elif event.keyval == gdk.KEY_Page_Up:
             self.y -= self.height * 0.8
             self.on_scroll()
-
-        elif event.keyval == gdk.KEY_Home:
-            self.set_current_fact(self.facts[0])
-
-        elif event.keyval == gdk.KEY_End:
-            self.set_current_fact(self.facts[-1])
 
         elif event.keyval == gdk.KEY_Return:
             if self.current_fact:

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -280,6 +280,8 @@ class FactTree(graphics.Scene, gtk.Scrollable):
             self.activate_row(self.hover_day, self.hover_fact)
 
     def on_key_press(self, scene, event):
+        # all keys should appear also in the Overview.on_key_press
+        # to be forwarded here even without focus.
         if event.keyval == gdk.KEY_Up:
             if self.current_fact:
                 idx = max(0, self.current_fact_index - 1)

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -312,7 +312,8 @@ class FactTree(graphics.Scene, gtk.Scrollable):
             self.set_current_fact(self.facts[-1])
 
         elif event.keyval == gdk.KEY_Return:
-            self.activate_row(self.hover_day, self.current_fact)
+            if self.current_fact:
+                self.activate_row(self.hover_day, self.current_fact)
 
         elif event.keyval == gdk.KEY_Delete:
             self.delete_row(self.current_fact)

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -273,8 +273,7 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         self.emit("on-activate-row", day, fact)
 
     def delete_row(self, fact):
-        if fact:
-            self.emit("on-delete-called", fact)
+        self.emit("on-delete-called", fact)
 
     def on_double_click(self, scene, event):
         if self.hover_fact:
@@ -316,7 +315,8 @@ class FactTree(graphics.Scene, gtk.Scrollable):
                 self.activate_row(self.hover_day, self.current_fact)
 
         elif event.keyval == gdk.KEY_Delete:
-            self.delete_row(self.current_fact)
+            if self.current_fact:
+                self.delete_row(self.current_fact)
 
 
     def set_current_fact(self, fact):


### PR DESCRIPTION
Shortcuts (#230)
Arrows to navigate between dates and facts.

### checks
The following are tests, and show potential uses.

Left/Right arrow: change dates

With nothing selected
Ctrl-R: do nothing
Ctrl-N: new empty fact
Ctrl-+: new empty fact
Ctrl-Enter or Enter: do nothing

Select one fact
Ctrl-R clone, starting now
Ctrl-N new empty fact
Ctrl-+ clone, starting now
Ctrl-Enter or Enter: edit selected fact

Create a new fact
if not selected
Delete: do nothing
select the fact
Delete: fact deleted

With enough dates to have more facts than can fit in the overview,
to check scrolling,
check that the following keys work also right at the start of overview,
(without having to focus on the FactTree itself)
Up, Down,
Home, End (change selected fact)
Page up, Page down, (just scroll)

With an ongoing fact
Ctrl+Space: stop
