### PR TITLE
add PangoCairo require_version

### DIFF
--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -25,6 +25,8 @@ import re
 from gi.repository import Gdk as gdk
 from gi.repository import Gtk as gtk
 from gi.repository import GObject as gobject
+import gi
+gi.require_version('PangoCairo', '1.0')
 from gi.repository import PangoCairo as pangocairo
 from gi.repository import Pango as pango
 from collections import defaultdict


### PR DESCRIPTION
Otherwise there was
> PyGIWarning: PangoCairo was imported without specifying a version first.

upon 
```bash
src/hamster-cli add
```