### PR TITLE
Fix dark theme colors

### DIFF
--- a/src/hamster/lib/graphics.py
+++ b/src/hamster/lib/graphics.py
@@ -120,7 +120,27 @@ class ColorUtils(object):
             return colorsys.hls_to_rgb(hls[0], hls[1] + step, hls[2])
         # returns color darker by step (where step is in range 0..255)
 
+    def mix(self, ca, cb, xb):
+        """Mix colors.
+
+        Args:
+            ca (gdk.RGBA): first color
+            cb (gdk.RGBA): second color
+            xb (float): between 0.0 and 1.0
+
+        Return:
+            gdk.RGBA: linear interpolation between ca and cb,
+                      0 or 1 return the unaltered 1st or 2nd color respectively,
+                      as in CSS.
+        """
+        r = (1 - xb) * ca.red + xb * cb.red
+        g = (1 - xb) * ca.green + xb * cb.green
+        b = (1 - xb) * ca.blue + xb * cb.blue
+        a = (1 - xb) * ca.alpha + xb * cb.alpha
+        return gdk.RGBA(red=r, green=g, blue=b, alpha=a)
+
 Colors = ColorUtils() # this is a static class, so an instance will do
+
 
 def get_gdk_rectangle(x, y, w, h):
     rect = gdk.Rectangle()

--- a/src/hamster/lib/graphics.py
+++ b/src/hamster/lib/graphics.py
@@ -98,8 +98,15 @@ class ColorUtils(object):
         return gdk.Color.from_floats(c)
 
     def hex(self, color):
-        c = self.parse(color)
-        return "#" + "".join("{:02x}".format(int(color) * 255) for color in c)
+        if isinstance(color, gdk.RGBA):
+            r = int(255 * color.red)
+            g = int(255 * color.green)
+            b = int(255 * color.blue)
+            a = int(255 * color.alpha)
+            return "#{:02x}{:02x}{:02x}{:02x}".format(r, g, b, a)
+        else:
+            c = self.parse(color)
+            return "#" + "".join("{:02x}".format(int(color) * 255) for color in c)
 
     def is_light(self, color):
         """tells you if color is dark or light, so you can up or down the

--- a/src/hamster/lib/layout.py
+++ b/src/hamster/lib/layout.py
@@ -884,13 +884,13 @@ class Label(Bin):
 
     def __setattr__(self, name, val):
         if name in ("text", "markup", "color", "size"):
-            if self.display_label.__dict__.get(name, "hamster_graphics_no_value_really") == val:
+            if self.display_label.__dict__.get(name, "hamster_graphics_no_value_really") is val:
                 return
             setattr(self.display_label, name, val)
         elif name in ("spacing"):
             setattr(self.container, name, val)
         else:
-            if self.__dict__.get(name, "hamster_graphics_no_value_really") == val:
+            if self.__dict__.get(name, "hamster_graphics_no_value_really") is val:
                 return
             Bin.__setattr__(self, name, val)
 

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -300,6 +300,7 @@ class Totals(graphics.Scene):
         self.connect("on-click", self.on_click)
         self.connect("enter-notify-event", self.on_mouse_enter)
         self.connect("leave-notify-event", self.on_mouse_leave)
+        self.connect("style-updated", self.on_style_changed)
 
 
     def set_facts(self, facts):
@@ -364,6 +365,9 @@ class Totals(graphics.Scene):
         self.height_proxy.animate(x=50, delay=0.5, duration=0,
                                   on_complete=delayed_leave,
                                   on_update=lambda sprite: sprite.redraw())
+
+    def on_style_changed(self, _):
+        self.instructions_label.color = self._style.get_color(self.get_state())
 
     def change_height(self, new_height):
         self.stop_animation(self.height_proxy)

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -254,8 +254,7 @@ class Totals(graphics.Scene):
     def __init__(self):
         graphics.Scene.__init__(self)
         self.set_size_request(200, 70)
-        self.category_totals = layout.Label(color=self._style.get_color(gtk.StateFlags.NORMAL),
-                                            overflow=pango.EllipsizeMode.END,
+        self.category_totals = layout.Label(overflow=pango.EllipsizeMode.END,
                                             x_align=0,
                                             expand=False)
         self.stacked_bar = StackedBar(height=25, x_align=0, expand=False)
@@ -300,6 +299,7 @@ class Totals(graphics.Scene):
         self.connect("on-click", self.on_click)
         self.connect("enter-notify-event", self.on_mouse_enter)
         self.connect("leave-notify-event", self.on_mouse_leave)
+        self.connect("state-flags-changed", self.on_state_flags_changed)
         self.connect("style-updated", self.on_style_changed)
 
 
@@ -366,8 +366,11 @@ class Totals(graphics.Scene):
                                   on_complete=delayed_leave,
                                   on_update=lambda sprite: sprite.redraw())
 
+    def on_state_flags_changed(self, previous_state, _):
+        self.update_colors()
+
     def on_style_changed(self, _):
-        self.instructions_label.color = self._style.get_color(self.get_state())
+        self.update_colors()
 
     def change_height(self, new_height):
         self.stop_animation(self.height_proxy)
@@ -379,7 +382,9 @@ class Totals(graphics.Scene):
                      on_update=on_update_dummy,
                      easing=Easing.Expo.ease_out)
 
-
+    def update_colors(self):
+        self.instructions_label.color = self._style.get_color(self.get_state())
+        self.category_totals.color = self._style.get_color(self.get_state())
 
 
 class Overview(Controller):

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -209,6 +209,8 @@ class HorizontalBarChart(graphics.Sprite):
         self.layout.set_justify(True)
         self.layout.set_alignment(pango.Alignment.RIGHT)
         self.label_height = self.layout.get_pixel_size()[1]
+        # should be updated by the parent
+        self.label_color = gdk.RGBA()
 
         self._max = dt.timedelta(0)
 
@@ -230,7 +232,7 @@ class HorizontalBarChart(graphics.Sprite):
         label_h = self.label_height
         bar_start_x = label_width + margin
         for i, (label, value) in enumerate(self.values):
-            g.set_color("#333")
+            g.set_color(self.label_color)
             duration_str = stuff.format_duration(value, human=False)
             markup_label = stuff.escape_pango(str(label))
             markup_duration = stuff.escape_pango(duration_str)
@@ -383,8 +385,12 @@ class Totals(graphics.Scene):
                      easing=Easing.Expo.ease_out)
 
     def update_colors(self):
-        self.instructions_label.color = self._style.get_color(self.get_state())
-        self.category_totals.color = self._style.get_color(self.get_state())
+        color = self._style.get_color(self.get_state())
+        self.instructions_label.color = color
+        self.category_totals.color = color
+        self.activities_chart.label_color = color
+        self.categories_chart.label_color = color
+        self.tag_chart.label_color = color
 
 
 class Overview(Controller):

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -211,6 +211,7 @@ class HorizontalBarChart(graphics.Sprite):
         self.label_height = self.layout.get_pixel_size()[1]
         # should be updated by the parent
         self.label_color = gdk.RGBA()
+        self.bar_color = gdk.RGBA()
 
         self._max = dt.timedelta(0)
 
@@ -246,7 +247,7 @@ class HorizontalBarChart(graphics.Sprite):
             else:
                 w = 1
             g.rectangle(bar_start_x, y, int(w), int(label_h))
-            g.fill("#999")
+            g.fill(self.bar_color)
 
         g.restore_context()
 
@@ -391,6 +392,11 @@ class Totals(graphics.Scene):
         self.activities_chart.label_color = color
         self.categories_chart.label_color = color
         self.tag_chart.label_color = color
+        bg_color = self._style.get_background_color(self.get_state())
+        bar_color = self.colors.mix(bg_color, color, 0.6)
+        self.activities_chart.bar_color = bar_color
+        self.categories_chart.bar_color = bar_color
+        self.tag_chart.bar_color = bar_color
 
 
 class Overview(Controller):

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -185,10 +185,12 @@ class CompleteTree(graphics.Scene):
 
             label = row.label
             if row.description:
-                description_color = graphics.Colors.contrast(color, 50)
-                description_color = graphics.Colors.hex(description_color)
+                description_color = graphics.Colors.mix(bg, color, 0.75)
+                description_color_str = graphics.Colors.hex(description_color)
 
-                label += '<span color="%s">  [%s]</span>' % (description_color, row.description)
+                label = '{}  <span color="{}">[{}]</span>'.format(label,
+                                                                  description_color_str,
+                                                                  row.description)
 
             self.label.show(g, label, color=color)
 

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -527,7 +527,8 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         g.set_line_style(1)
         g.translate(0.5, 0.5)
 
-        g.fill_area(0, 0, 105, self.height, "#dfdfdf")
+        date_bg_color = self.colors.mix(colors["normal_bg"], colors["normal"], 0.15)
+        g.fill_area(0, 0, 105, self.height, date_bg_color)
 
 
         y = int(self.y)

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -542,11 +542,14 @@ class FactTree(graphics.Scene, gtk.Scrollable):
                 g.rectangle(0, 0, self.width, 10)
                 g.clip()
                 g.rectangle(0, 0, self.width, 10)
-                g.fill("#eee")
+                none_bg_color = self.colors.mix(colors["normal_bg"], colors["normal"], 0.75)
+                g.fill(none_bg_color)
 
+                # line, useful to separate consecutive days with no activity
                 g.move_to(0, 0)
                 g.line_to(self.width, 0)
-                g.stroke("#ccc")
+                none_stroke_color = self.colors.mix(colors["normal_bg"], colors["normal"], 0.25)
+                g.stroke(none_stroke_color)
                 g.restore_context()
                 continue
 


### PR DESCRIPTION
Fixed by using functions that are labeled "obsolete" in the documentation,
but still the only workaround to [color issues](https://gitlab.gnome.org/GNOME/pygobject/issues/119).

CSS seemed really nice, but it actually was a nightmare for me to migrate to.
Too many gaps to cross in an otherwise well written gtk documentation,
lots of obsolete stuff online,
and the extensive use of pango/cairo in hamster probably did not help.
This is another place where the rewrite (already using CSS)
seems to be the way to go in the long run.

For testers, [GtkInspector](https://blog.gtk.org/2017/04/05/the-gtk-inspector/) is an awesome tool for debugging theme issues:
```bash
GTK_DEBUG=interactive src/hamster-cli
```
Make sure to check out the `Visual` tab and its `Gtk Theme` combo box
(change theme quickly by mouse wheel).
