### PR TITLE
remove gobject import

### DIFF
--- a/src/hamster-service
+++ b/src/hamster-service
@@ -2,7 +2,6 @@
 # nicked off gwibber
 
 import logging
-from gi.repository import GObject as gobject
 from gi.repository import GLib as glib
 
 import dbus, dbus.service

--- a/src/hamster-windows-service
+++ b/src/hamster-windows-service
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # nicked off hamster-service
 
-from gi.repository import GObject as gobject
 from gi.repository import GLib as glib
 import dbus, dbus.service
 from dbus.mainloop.glib import DBusGMainLoop


### PR DESCRIPTION
Merged #404 too fast. The `gobject` import lines are no longer used.