### PR TITLE
RFC: preselect time instead of activity

### DIFF
--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -83,7 +83,7 @@ class CustomFactController(gobject.GObject):
             with self.activity.handler_block(self.activity.checker):
                 self.activity.set_text(label)
                 time_len = len(label) - len(original_fact.serialized_name())
-                self.activity.select_region(time_len, -1)
+                self.activity.select_region(0, time_len - 1)
             buf = gtk.TextBuffer()
             buf.set_text(original_fact.description or "")
             self.get_widget('description').set_buffer(buf)


### PR DESCRIPTION
Most often, it is the time that has to be changed (at least for me).
This is especially true when cloning.

This changes the initial selection in the activity entry line
to be the time information.

Selecting the body can be done quickly by pressing `Right arrow` then  `Shift+End`.

Is there a a consensus about this, or do we have to add an option ?