### PR TITLE
wscript: install bash completion to /usr/share

### DIFF
--- a/wscript
+++ b/wscript
@@ -51,7 +51,8 @@ def build(bld):
     bld.install_as('${BINDIR}/hamster', "src/hamster-cli", chmod = 0755)
 
 
-    bld.install_files('${SYSCONFDIR}/bash_completion.d','src/hamster.bash')
+    bld.install_files('${PREFIX}/share/bash-completion/completion',
+                      'src/hamster.bash')
 
 
     # set correct flags in defs.py


### PR DESCRIPTION
The patch from mwilck for opensuse gets bash completion working on my Ubuntu 19.04 too. See https://build.opensuse.org/package/view_file/openSUSE:Factory/hamster-time-tracker/0005-wscript-install-bash-completion-to-usr-share-bash-co.patch?expand=1