### PR TITLE
Fix too small fonts on high DPI screens

### DIFF
--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -22,7 +22,6 @@ import cairo
 import datetime as dt
 
 from collections import defaultdict
-
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
@@ -31,7 +30,6 @@ from gi.repository import Pango as pango
 
 from hamster.lib import graphics
 from hamster.lib import stuff
-
 
 
 class ActionRow(graphics.Sprite):
@@ -103,20 +101,8 @@ class FactRow(object):
         self.activity_label = Label(x=100)
 
         self.category_label = Label()
-        fontdesc = pango.FontDescription(graphics._font_desc)
-        fontdesc.set_size(10 * pango.SCALE)
-        self.category_label.layout.set_font_description(fontdesc)
-
-
         self.description_label = Label()
-        fontdesc = pango.FontDescription(graphics._font_desc)
-        fontdesc.set_style(pango.Style.ITALIC)
-        self.description_label.layout.set_font_description(fontdesc)
-
         self.tag_label = Label()
-        fontdesc = pango.FontDescription(graphics._font_desc)
-        fontdesc.set_size(8 * pango.SCALE)
-        self.tag_label.layout.set_font_description(fontdesc)
 
         self.duration_label = Label()
         self.duration_label.layout.set_alignment(pango.Alignment.RIGHT)
@@ -132,7 +118,6 @@ class FactRow(object):
         self.inter_tag_margin = 4
         self.row_margin_H = 5
         self.row_margin_V = 2
-        self.category_offset_V = 2
 
 
     @property
@@ -172,7 +157,7 @@ class FactRow(object):
         if fact.tags:
             # for now, tags are on a single line.
             # The first one is enough to determine the height.
-            self.tag_label.set_text(fact.tags[0])
+            self.tag_label.set_text( "<small>{}</small>".format(fact.tags[0]))
 
 
     def _show_tags(self, g, color, bg):
@@ -182,7 +167,7 @@ class FactRow(object):
         g.save_context()
         g.translate(self.tag_row_margin_H, self.tag_row_margin_V)
         for tag in self.fact.tags:
-            label.set_text(tag)
+            label.set_text("<small>{}</small>".format(tag))
             w, h = label.layout.get_pixel_size()
             rw = w + self.tag_inner_margin_H * 2
             rh = h + self.tag_inner_margin_V * 2
@@ -222,7 +207,7 @@ class FactRow(object):
             category_color = graphics.ColorUtils.mix(bg, color, 0.57)
             g.set_color(category_color)
             x = self.activity_label.x + self.activity_label.layout.get_pixel_size()[0]
-            self.category_label.show(g, x=x, y=self.category_offset_V)
+            self.category_label.show(g, x=x, y=0)
             g.restore_context()
 
         if self.fact.description or self.fact.tags:

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -95,6 +95,12 @@ class Label(object):
         g.restore_context()
 
 
+class TagLabel(Label):
+    """Tag label, with small text."""
+    def set_text(self, text):
+        Label.set_text(self, "<small>{}</small>".format(text))
+
+
 class FactRow(object):
     def __init__(self):
         self.time_label = Label()
@@ -102,7 +108,7 @@ class FactRow(object):
 
         self.category_label = Label()
         self.description_label = Label()
-        self.tag_label = Label()
+        self.tag_label = TagLabel()
 
         self.duration_label = Label()
         self.duration_label.layout.set_alignment(pango.Alignment.RIGHT)
@@ -157,7 +163,7 @@ class FactRow(object):
         if fact.tags:
             # for now, tags are on a single line.
             # The first one is enough to determine the height.
-            self.tag_label.set_text( "<small>{}</small>".format(fact.tags[0]))
+            self.tag_label.set_text(stuff.escape_pango(fact.tags[0]))
 
 
     def _show_tags(self, g, color, bg):
@@ -167,7 +173,7 @@ class FactRow(object):
         g.save_context()
         g.translate(self.tag_row_margin_H, self.tag_row_margin_V)
         for tag in self.fact.tags:
-            label.set_text("<small>{}</small>".format(stuff.escape_pango(tag)))
+            label.set_text(stuff.escape_pango(tag))
             w, h = label.layout.get_pixel_size()
             rw = w + self.tag_inner_margin_H * 2
             rh = h + self.tag_inner_margin_V * 2

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -124,7 +124,7 @@ class FactRow(object):
         self.inter_tag_margin = 4
         self.row_margin_H = 5
         self.row_margin_V = 2
-
+        self.category_offset_V = self.category_label.height * 0.1;
 
     @property
     def height(self):
@@ -213,7 +213,7 @@ class FactRow(object):
             category_color = graphics.ColorUtils.mix(bg, color, 0.57)
             g.set_color(category_color)
             x = self.activity_label.x + self.activity_label.layout.get_pixel_size()[0]
-            self.category_label.show(g, x=x, y=0)
+            self.category_label.show(g, x=x, y=self.category_offset_V)
             g.restore_context()
 
         if self.fact.description or self.fact.tags:

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -167,7 +167,7 @@ class FactRow(object):
         g.save_context()
         g.translate(self.tag_row_margin_H, self.tag_row_margin_V)
         for tag in self.fact.tags:
-            label.set_text("<small>{}</small>".format(tag))
+            label.set_text("<small>{}</small>".format(stuff.escape_pango(tag)))
             w, h = label.layout.get_pixel_size()
             rw = w + self.tag_inner_margin_H * 2
             rh = h + self.tag_inner_margin_V * 2

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -157,7 +157,8 @@ class FactRow(object):
         category_text = "  - {}".format(stuff.escape_pango(fact.category)) if fact.category else ""
         self.category_label.set_text(category_text)
 
-        description_text = "<small>{}</small>".format(stuff.escape_pango(fact.description)) if fact.description else ""
+        text = stuff.escape_pango(fact.description)
+        description_text = "<small><i>{}</i></small>".format(text) if fact.description else ""
         self.description_label.set_text(description_text)
 
         if fact.tags:


### PR DESCRIPTION
The use of pango.SCALE to set font sizes results in fonts that are too small on high DPI screens (see #312 and #289). This pull request attempts to resolve the issue by only using relative font sizes (i.e. &lt;small&gt; tag) in the fact tree display.