### PR TITLE
Date/time tweaks

### DIFF
--- a/src/hamster-cli
+++ b/src/hamster-cli
@@ -62,7 +62,7 @@ def fact_dict(fact_data, with_date):
     if fact_data.end_time:
         fact['end'] = fact_data.end_time.strftime(fmt)
     else:
-        end_date = dt.datetime.now()
+        end_date = stuff.dt_now()
         fact['end'] = ''
 
     fact['duration'] = stuff.format_duration(fact_data.delta)
@@ -99,7 +99,7 @@ def parse_datetime_range(arg):
     # bail out early on relative minutes
     if fragments['relative']:
         delta_minutes = int(fragments['relative'])
-        return dt.datetime.now() - dt.timedelta(minutes=delta_minutes), rest
+        return dt_now() - dt.timedelta(minutes=delta_minutes), rest
 
     start_time, end_time = None, None
 
@@ -114,13 +114,14 @@ def parse_datetime_range(arg):
                 pass
         return None
 
+    now = stuff.dt_now()
 
     if fragments['date1'] or fragments['time1']:
         start_time = dt.datetime.combine(to_time(fragments['date1']) or dt.date.today(),
-                                         to_time(fragments['time1']) or dt.time())
+                                         to_time(fragments['time1']) or now)
     if fragments['date2'] or fragments['time2']:
         end_time = dt.datetime.combine(to_time(fragments['date2']) or start_time or dt.date.today(),
-                                       to_time(fragments['time2']) or dt.time())
+                                       to_time(fragments['time2']) or now)
 
     return start_time, end_time
 
@@ -196,7 +197,7 @@ class HamsterClient(object):
 
         activity = args[0]
         start_time, end_time = parse_datetime_range(" ".join(args[1:]))
-        start_time = start_time or dt.datetime.now()
+        start_time = start_time or stuff.dt_now()
 
         self.storage.add_fact(Fact(activity,
                                          start_time = start_time,
@@ -371,7 +372,7 @@ Actions:
     * overview / statistics / about: launch specific window
 
 Time formats:
-    * 'YYYY-MM-DD hh:mm:ss': If date is missing, it will default to today.
+    * 'YYYY-MM-DD hh:mm': If date is missing, it will default to today.
       If time is missing, it will default to 00:00 for start time and 23:59 for
       end time.
     * '-minutes': Relative time in minutes from the current date and time.
@@ -388,22 +389,22 @@ Example usage:
 
     import signal
     signal.signal(signal.SIGINT, signal.SIG_DFL) # gtk3 screws up ctrl+c
-    
+
     parser = argparse.ArgumentParser(
         description="Time tracking utility",
         epilog=usage,
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
     # cf. https://stackoverflow.com/a/28611921/3565696
-    parser.add_argument("--log", dest="log_level", 
+    parser.add_argument("--log", dest="log_level",
                         choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'),
                         default='WARNING',
                         help="Set the logging level (default: %(default)s)")
     parser.add_argument("action", nargs="?", default="overview")
     parser.add_argument('action_args', nargs=argparse.REMAINDER, default=[])
-    
+
     args = parser.parse_args()
-    
+
     # logger for current script
     logger.setLevel(args.log_level)
     # hamster_logger for the rest

--- a/src/hamster-cli
+++ b/src/hamster-cli
@@ -62,7 +62,7 @@ def fact_dict(fact_data, with_date):
     if fact_data.end_time:
         fact['end'] = fact_data.end_time.strftime(fmt)
     else:
-        end_date = stuff.dt_now()
+        end_date = stuff.hamster_now()
         fact['end'] = ''
 
     fact['duration'] = stuff.format_duration(fact_data.delta)
@@ -99,7 +99,7 @@ def parse_datetime_range(arg):
     # bail out early on relative minutes
     if fragments['relative']:
         delta_minutes = int(fragments['relative'])
-        return stuff.dt_now() - dt.timedelta(minutes=delta_minutes), rest
+        return stuff.hamster_now() - dt.timedelta(minutes=delta_minutes), rest
 
     start_time, end_time = None, None
 
@@ -114,7 +114,7 @@ def parse_datetime_range(arg):
                 pass
         return None
 
-    now = stuff.dt_now()
+    now = stuff.hamster_now()
 
     if fragments['date1'] or fragments['time1']:
         start_time = dt.datetime.combine(to_time(fragments['date1']) or dt.date.today(),
@@ -197,7 +197,7 @@ class HamsterClient(object):
 
         activity = args[0]
         start_time, end_time = parse_datetime_range(" ".join(args[1:]))
-        start_time = start_time or stuff.dt_now()
+        start_time = start_time or stuff.hamster_now()
 
         self.storage.add_fact(Fact(activity,
                                          start_time = start_time,

--- a/src/hamster-cli
+++ b/src/hamster-cli
@@ -114,7 +114,7 @@ def parse_datetime_range(arg):
                 pass
         return None
 
-    now = stuff.hamster_now()
+    now = stuff.hamster_now().time()
 
     if fragments['date1'] or fragments['time1']:
         start_time = dt.datetime.combine(to_time(fragments['date1']) or dt.date.today(),

--- a/src/hamster-cli
+++ b/src/hamster-cli
@@ -99,7 +99,7 @@ def parse_datetime_range(arg):
     # bail out early on relative minutes
     if fragments['relative']:
         delta_minutes = int(fragments['relative'])
-        return dt_now() - dt.timedelta(minutes=delta_minutes), rest
+        return stuff.dt_now() - dt.timedelta(minutes=delta_minutes), rest
 
     start_time, end_time = None, None
 

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -23,7 +23,7 @@ import datetime as dt
 from calendar import timegm
 import dbus, dbus.mainloop.glib
 from gi.repository import GObject as gobject
-from hamster.lib import Fact, dt_now
+from hamster.lib import Fact, hamster_now
 
 def from_dbus_fact(fact):
     """unpack the struct into a proper dict"""
@@ -183,7 +183,7 @@ class Storage(gobject.GObject):
 
         serialized = fact.serialized_name()
 
-        start_timestamp = timegm((fact.start_time or dt_now()).timetuple())
+        start_timestamp = timegm((fact.start_time or hamster_now()).timetuple())
 
         end_timestamp = fact.end_time or 0
         if end_timestamp:
@@ -201,7 +201,7 @@ class Storage(gobject.GObject):
     def stop_tracking(self, end_time = None):
         """Stop tracking current activity. end_time can be passed in if the
         activity should have other end time than the current moment"""
-        end_time = timegm((end_time or dt_now()).timetuple())
+        end_time = timegm((end_time or hamster_now()).timetuple())
         return self.conn.StopTracking(end_time)
 
     def remove_fact(self, fact_id):
@@ -215,7 +215,7 @@ class Storage(gobject.GObject):
         from the fact dict that is returned by this function"""
 
 
-        start_time = timegm((fact.start_time or dt_now()).timetuple())
+        start_time = timegm((fact.start_time or hamster_now()).timetuple())
 
         end_time = fact.end_time or 0
         if end_time:

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -23,7 +23,7 @@ import datetime as dt
 from calendar import timegm
 import dbus, dbus.mainloop.glib
 from gi.repository import GObject as gobject
-from hamster.lib import Fact
+from hamster.lib import Fact, dt_now
 
 def from_dbus_fact(fact):
     """unpack the struct into a proper dict"""
@@ -183,7 +183,7 @@ class Storage(gobject.GObject):
 
         serialized = fact.serialized_name()
 
-        start_timestamp = timegm((fact.start_time or dt.datetime.now()).timetuple())
+        start_timestamp = timegm((fact.start_time or dt_now()).timetuple())
 
         end_timestamp = fact.end_time or 0
         if end_timestamp:
@@ -201,7 +201,7 @@ class Storage(gobject.GObject):
     def stop_tracking(self, end_time = None):
         """Stop tracking current activity. end_time can be passed in if the
         activity should have other end time than the current moment"""
-        end_time = timegm((end_time or dt.datetime.now()).timetuple())
+        end_time = timegm((end_time or dt_now()).timetuple())
         return self.conn.StopTracking(end_time)
 
     def remove_fact(self, fact_id):
@@ -215,7 +215,7 @@ class Storage(gobject.GObject):
         from the fact dict that is returned by this function"""
 
 
-        start_time = timegm((fact.start_time or dt.datetime.now()).timetuple())
+        start_time = timegm((fact.start_time or dt_now()).timetuple())
 
         end_time = fact.end_time or 0
         if end_time:

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -28,7 +28,7 @@ import datetime as dt
 """
 from hamster import widgets
 from hamster.lib.configuration import runtime, conf, load_ui_file
-from hamster.lib.stuff import hamster_today
+from hamster.lib.stuff import hamster_today, dt_now
 from hamster.lib import Fact
 
 
@@ -73,7 +73,7 @@ class CustomFactController(gobject.GObject):
                 # start running now.
                 # Do not try to pass end_time=None to copy(), above;
                 # it would be discarded.
-                original_fact.start_time = dt.datetime.now()
+                original_fact.start_time = dt_now()
                 original_fact.end_time = None
             else:
                 original_fact = None
@@ -127,7 +127,7 @@ class CustomFactController(gobject.GObject):
         if fact.start_time:
             fact.date = self.date
         else:
-            fact.start_time = dt.datetime.now()
+            fact.start_time = dt_now()
         return fact
 
 
@@ -151,7 +151,7 @@ class CustomFactController(gobject.GObject):
     def validate_fields(self, widget = None):
         fact = self.localized_fact()
 
-        now = dt.datetime.now()
+        now = dt_now()
         self.get_widget("button-next-day").set_sensitive(self.date < now.date())
 
         if self.date != now.date():

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -28,7 +28,7 @@ import datetime as dt
 """
 from hamster import widgets
 from hamster.lib.configuration import runtime, conf, load_ui_file
-from hamster.lib.stuff import hamster_today, dt_now
+from hamster.lib.stuff import hamster_today, hamster_now
 from hamster.lib import Fact
 
 
@@ -73,7 +73,7 @@ class CustomFactController(gobject.GObject):
                 # start running now.
                 # Do not try to pass end_time=None to copy(), above;
                 # it would be discarded.
-                original_fact.start_time = dt_now()
+                original_fact.start_time = hamster_now()
                 original_fact.end_time = None
             else:
                 original_fact = None
@@ -127,7 +127,7 @@ class CustomFactController(gobject.GObject):
         if fact.start_time:
             fact.date = self.date
         else:
-            fact.start_time = dt_now()
+            fact.start_time = hamster_now()
         return fact
 
 
@@ -151,7 +151,7 @@ class CustomFactController(gobject.GObject):
     def validate_fields(self, widget = None):
         fact = self.localized_fact()
 
-        now = dt_now()
+        now = hamster_now()
         self.get_widget("button-next-day").set_sensitive(self.date < now.date())
 
         if self.date != now.date():

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -8,7 +8,7 @@ import re
 from hamster.lib.stuff import (
     datetime_to_hamsterday,
     hamsterday_time_to_datetime,
-    dt_now,
+    hamster_now,
 )
 
 
@@ -67,7 +67,7 @@ def figure_time(str_time):
     if (hours is None or minutes is None) or hours > 24 or minutes > 60:
         return None #no can do
 
-    return dt_now()
+    return hamster_now()
 
 
 class Fact(object):
@@ -171,7 +171,7 @@ class Fact(object):
     @property
     def delta(self):
         """Duration (datetime.timedelta)."""
-        end_time = self.end_time if self.end_time else dt_now()
+        end_time = self.end_time if self.end_time else hamster_now()
         return end_time - self.start_time
 
     def serialized_name(self):
@@ -234,7 +234,7 @@ def parse_fact(text, phase=None, res=None, date=None):
         [date] start_time[-end_time] activity[@category][, description]{[,] { })#tag}
         According to the legacy tests, # were allowed in the description
     """
-    now = dt_now()
+    now = hamster_now()
 
     # determine what we can look for
     phases = [

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -8,6 +8,7 @@ import re
 from hamster.lib.stuff import (
     datetime_to_hamsterday,
     hamsterday_time_to_datetime,
+    dt_now,
 )
 
 
@@ -66,8 +67,7 @@ def figure_time(str_time):
     if (hours is None or minutes is None) or hours > 24 or minutes > 60:
         return None #no can do
 
-    return dt.datetime.now().replace(hour = hours, minute = minutes,
-                                     second = 0, microsecond = 0)
+    return dt_now()
 
 
 class Fact(object):
@@ -171,7 +171,7 @@ class Fact(object):
     @property
     def delta(self):
         """Duration (datetime.timedelta)."""
-        end_time = self.end_time if self.end_time else dt.datetime.now()
+        end_time = self.end_time if self.end_time else dt_now()
         return end_time - self.start_time
 
     def serialized_name(self):
@@ -234,7 +234,7 @@ def parse_fact(text, phase=None, res=None, date=None):
         [date] start_time[-end_time] activity[@category][, description]{[,] { })#tag}
         According to the legacy tests, # were allowed in the description
     """
-    now = dt.datetime.now()
+    now = dt_now()
 
     # determine what we can look for
     phases = [

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -11,7 +11,7 @@ from hamster.lib.stuff import (
 )
 
 
-DATE_FMT = "%d-%m-%Y"
+DATE_FMT = "%Y-%m-%d"
 TIME_FMT = "%H:%M"
 
 

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -182,6 +182,9 @@ def duration_minutes(duration):
     else:
         return duration
 
+def dt_now():
+    # current datetime truncated to the minute
+    return dt.datetime.now().replace(second=0, microsecond=0)
 
 def zero_hour(date):
     return dt.datetime.combine(date.date(), dt.time(0,0))

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -59,6 +59,11 @@ def datetime_to_hamsterday(civil_date_time):
     return hamster_date_time.date()
 
 
+def hamster_now():
+    # current datetime truncated to the minute
+    return dt.datetime.now().replace(second=0, microsecond=0)
+
+
 def hamster_today():
     """Return the current hamster day."""
     return datetime_to_hamsterday(dt.datetime.now())
@@ -182,9 +187,6 @@ def duration_minutes(duration):
     else:
         return duration
 
-def dt_now():
-    # current datetime truncated to the minute
-    return dt.datetime.now().replace(second=0, microsecond=0)
 
 def zero_hour(date):
     return dt.datetime.combine(date.date(), dt.time(0,0))

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -66,7 +66,7 @@ def hamster_now():
 
 def hamster_today():
     """Return the current hamster day."""
-    return datetime_to_hamsterday(dt.datetime.now())
+    return datetime_to_hamsterday(hamster_now())
 
 
 def hamsterday_time_to_datetime(hamsterday, time):

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -629,8 +629,8 @@ class Storage(storage.Storage):
             day_start = conf.day_start
         except:
             day_start = dt.time(5, 0)  # default: 5:00
-        today = (hamster_now() - dt.timedelta(hours = day_start.hour,
-                                                  minutes = day_start.minute)).date()
+        today = (hamster_now() - dt.timedelta(hours=day_start.hour,
+                                              minutes=day_start.minute)).date()
         return self.__get_facts(today)
 
 

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -548,7 +548,7 @@ class Storage(storage.Storage):
             activity_id = activity_id['id']
 
         # if we are working on +/- current day - check the last_activity
-        if (dt.timedelta(days=-1) <= dt.datetime.now() - start_time <= dt.timedelta(days=1)):
+        if (dt.timedelta(days=-1) <= hamster_now() - start_time <= dt.timedelta(days=1)):
             # pull in previous facts
             facts = self.__get_todays_facts()
 
@@ -629,7 +629,7 @@ class Storage(storage.Storage):
             day_start = conf.day_start
         except:
             day_start = dt.time(5, 0)  # default: 5:00
-        today = (dt.datetime.now() - dt.timedelta(hours = day_start.hour,
+        today = (hamster_now() - dt.timedelta(hours = day_start.hour,
                                                   minutes = day_start.minute)).date()
         return self.__get_facts(today)
 
@@ -700,7 +700,7 @@ class Storage(storage.Storage):
             if fact["end_time"]:
                 fact_end_time = fact["end_time"]
             elif (hamster_today() == fact["start_time"].date()) or \
-                 (dt.datetime.now() - fact["start_time"]) <= dt.timedelta(hours=12):
+                 (hamster_now() - fact["start_time"]) <= dt.timedelta(hours=12):
                 fact_end_time = hamster_now()
             else:
                 fact_end_time = fact["start_time"]

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -47,7 +47,7 @@ except ImportError:
     gio = None
 
 from hamster.lib import Fact
-from hamster.lib.stuff import hamster_today, dt_now
+from hamster.lib.stuff import hamster_today, hamster_now
 
 
 class Storage(storage.Storage):
@@ -399,7 +399,7 @@ class Storage(storage.Storage):
 
 
     def __touch_fact(self, fact, end_time = None):
-        end_time = end_time or dt_now()
+        end_time = end_time or hamster_now()
         # tasks under one minute do not count
         if end_time - fact['start_time'] < datetime.timedelta(minutes = 1):
             self.__remove_fact(fact['id'])
@@ -472,7 +472,7 @@ class Storage(storage.Storage):
                                           start_time, end_time))
 
         for fact in conflicts:
-            fact_end_time = fact["end_time"] or dt_now()
+            fact_end_time = fact["end_time"] or hamster_now()
 
             # won't eliminate as it is better to have overlapping entries than loosing data
             if start_time < fact["start_time"] and end_time > fact_end_time:
@@ -701,7 +701,7 @@ class Storage(storage.Storage):
                 fact_end_time = fact["end_time"]
             elif (hamster_today() == fact["start_time"].date()) or \
                  (dt.datetime.now() - fact["start_time"]) <= dt.timedelta(hours=12):
-                fact_end_time = dt_now()
+                fact_end_time = hamster_now()
             else:
                 fact_end_time = fact["start_time"]
 

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -47,7 +47,7 @@ except ImportError:
     gio = None
 
 from hamster.lib import Fact
-from hamster.lib.stuff import hamster_today
+from hamster.lib.stuff import hamster_today, dt_now
 
 
 class Storage(storage.Storage):
@@ -399,12 +399,11 @@ class Storage(storage.Storage):
 
 
     def __touch_fact(self, fact, end_time = None):
-        end_time = end_time or dt.datetime.now()
+        end_time = end_time or dt_now()
         # tasks under one minute do not count
         if end_time - fact['start_time'] < datetime.timedelta(minutes = 1):
             self.__remove_fact(fact['id'])
         else:
-            end_time = end_time.replace(microsecond = 0)
             query = """
                        UPDATE facts
                           SET end_time = ?
@@ -473,7 +472,7 @@ class Storage(storage.Storage):
                                           start_time, end_time))
 
         for fact in conflicts:
-            fact_end_time = fact["end_time"] or dt.datetime.now()
+            fact_end_time = fact["end_time"] or dt_now()
 
             # won't eliminate as it is better to have overlapping entries than loosing data
             if start_time < fact["start_time"] and end_time > fact_end_time:
@@ -702,7 +701,7 @@ class Storage(storage.Storage):
                 fact_end_time = fact["end_time"]
             elif (hamster_today() == fact["start_time"].date()) or \
                  (dt.datetime.now() - fact["start_time"]) <= dt.timedelta(hours=12):
-                fact_end_time = dt.datetime.now().replace(microsecond = 0)
+                fact_end_time = dt_now()
             else:
                 fact_end_time = fact["start_time"]
 

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -20,6 +20,7 @@
 
 import datetime as dt
 from hamster.lib import Fact
+from hamster.lib.stuff import dt_now
 
 class Storage(object):
     def run_fixtures(self):
@@ -39,7 +40,7 @@ class Storage(object):
     # facts
     def add_fact(self, fact, start_time, end_time, temporary = False):
         fact = Fact(fact, start_time = start_time, end_time = end_time)
-        start_time = fact.start_time or dt.datetime.now().replace(second = 0, microsecond = 0)
+        start_time = fact.start_time or dt_now()
 
         self.start_transaction()
         result = self.__add_fact(fact.serialized_name(), start_time, end_time, temporary)

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -20,7 +20,7 @@
 
 import datetime as dt
 from hamster.lib import Fact
-from hamster.lib.stuff import dt_now
+from hamster.lib.stuff import hamster_now
 
 class Storage(object):
     def run_fixtures(self):
@@ -40,7 +40,7 @@ class Storage(object):
     # facts
     def add_fact(self, fact, start_time, end_time, temporary = False):
         fact = Fact(fact, start_time = start_time, end_time = end_time)
-        start_time = fact.start_time or dt_now()
+        start_time = fact.start_time or hamster_now()
 
         self.start_transaction()
         result = self.__add_fact(fact.serialized_name(), start_time, end_time, temporary)

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -285,7 +285,7 @@ class ActivityEntry(gtk.Entry):
         self.todays_facts = self.storage.get_todays_facts()
 
         # list of facts of last month
-        now = dt.datetime.now()
+        now = stuff.hamster_now()
         last_month = self.storage.get_facts(now - dt.timedelta(days=30), now)
 
         # naive recency and frequency rank
@@ -350,7 +350,7 @@ class ActivityEntry(gtk.Entry):
         res = []
 
         fact = Fact(text)
-        now = dt.datetime.now()
+        now = stuff.hamster_now()
 
         # figure out what we are looking for
         # time -> activity[@category] -> tags -> description

--- a/src/hamster/widgets/dayline.py
+++ b/src/hamster/widgets/dayline.py
@@ -92,7 +92,7 @@ class DayLine(graphics.Scene):
 
         self.day_start = conf.day_start
 
-        start_time = start_time or dt.datetime.now()
+        start_time = start_time or stuff.hamster_now()
 
         self.view_time = start_time or dt.datetime.combine(start_time.date(), self.day_start)
 
@@ -238,8 +238,8 @@ class DayLine(graphics.Scene):
                 pangocairo.show_layout(context, layout)
 
         #current time
-        if self.view_time < dt.datetime.now() < self.view_time + dt.timedelta(hours = self.scope_hours):
-            minutes = round((dt.datetime.now() - self.view_time).seconds / 60 / minute_pixel)
+        if self.view_time < stuff.hamster_now() < self.view_time + dt.timedelta(hours = self.scope_hours):
+            minutes = round((stuff.hamster_now() - self.view_time).seconds / 60 / minute_pixel)
             g.rectangle(minutes, 0, self.width, self.height)
             g.fill(colors['normal_bg'], 0.7)
 

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -4,6 +4,7 @@ sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), "../
 
 import unittest
 from hamster.lib import Fact
+from hamster.lib.stuff import hamster_now
 
 
 class TestActivityInputParsing(unittest.TestCase):
@@ -126,10 +127,10 @@ class TestActivityInputParsing(unittest.TestCase):
         self.assertNotEqual(fact1, fact2)
         import datetime as dt
         fact2 = fact1.copy()
-        fact2.start_time = dt.datetime.now()
+        fact2.start_time = hamster_now()
         self.assertNotEqual(fact1, fact2)
         fact2 = fact1.copy()
-        fact2.end_time = dt.datetime.now()
+        fact2.end_time = hamster_now()
         self.assertNotEqual(fact1, fact2)
         # wrong order
         fact2 = fact1.copy()


### PR DESCRIPTION
Improve consistency in date/time handling (#428) by:

* switching to ISO date format (%Y-%m-%d) in lib/* to be consistent with hamster-cli usage
* rounding (i.e. truncating) all activity start/end timestamps to the minute
** note that this only affects new and/or edited activities in the database