### PR TITLE
Fix update activity description ambiguity

### DIFF
--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -82,10 +82,12 @@ class CustomFactController(gobject.GObject):
                 original_fact = None
 
         if original_fact:
-            label = original_fact.serialized(prepend_date=False)
+            stripped_fact = original_fact.copy()
+            stripped_fact.description = None
+            label = stripped_fact.serialized(prepend_date=False)
             with self.activity.handler_block(self.activity.checker):
                 self.activity.set_text(label)
-                time_len = len(label) - len(original_fact.serialized_name())
+                time_len = len(label) - len(stripped_fact.serialized_name())
                 self.activity.select_region(0, time_len - 1)
             buf = gtk.TextBuffer()
             buf.set_text(original_fact.description or "")

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -59,6 +59,7 @@ class CustomFactController(gobject.GObject):
 
         self.description_box = self.get_widget('description')
         self.description_buffer = self.description_box.get_buffer()
+        self.description_buffer.connect("changed", self.on_description_changed)
 
         self.activity.grab_focus()
         if fact_id:
@@ -97,6 +98,9 @@ class CustomFactController(gobject.GObject):
         self._gui.connect_signals(self)
         self.validate_fields()
         self.window.show_all()
+
+    def on_description_changed(self, text):
+        self.validate_fields()
 
     def on_prev_day_clicked(self, button):
         self.date = self.date - dt.timedelta(days=1)

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -122,7 +122,7 @@ class CustomFactController(gobject.GObject):
         self.window.show()
 
     def figure_description(self):
-        buf = self.description_box.get_buffer()
+        buf = self.description_buffer
         description = buf.get_text(buf.get_start_iter(), buf.get_end_iter(), 0)
         return description.strip()
 

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -149,14 +149,8 @@ class CustomFactController(gobject.GObject):
         self.validate_fields()
 
     def update_status(self, looks_good, markup):
-        """Set icon image and markup."""
-        if looks_good:
-            icon_name = "dialog-ok"
-        else:
-            icon_name = "dialog-error"
-        position = gtk.EntryIconPosition.SECONDARY
-        self.activity.set_icon_from_icon_name(position, icon_name)
-        self.activity.set_icon_tooltip_markup(position, markup)
+        """Set save button sensitivity and tooltip."""
+        self.save_button.set_tooltip_markup(markup)
         self.save_button.set_sensitive(looks_good)
 
     def validate_fields(self):

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -160,7 +160,7 @@ class CustomFactController(gobject.GObject):
         self.get_widget("save_button").set_sensitive(looks_good)
 
 
-    def validate_fields(self, widget = None):
+    def validate_fields(self):
         """Check entry and description validity."""
         fact = self.localized_fact()
 

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -158,7 +158,10 @@ class CustomFactController(gobject.GObject):
         self.get_widget("save_button").set_sensitive(looks_good)
 
     def validate_fields(self):
-        """Check entry and description validity.
+        """Check fields information.
+
+        Update gui status about entry and description validity.
+        Try to merge date, activity and description informations.
 
         Return the consolidated fact if successful, or None.
         """

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -58,6 +58,7 @@ class CustomFactController(gobject.GObject):
         self._gui.get_object("day_preview").add(self.dayline)
 
         self.description_box = self.get_widget('description')
+        self.description_buffer = self.description_box.get_buffer()
 
         self.activity.grab_focus()
         if fact_id:
@@ -89,9 +90,7 @@ class CustomFactController(gobject.GObject):
                 self.activity.set_text(label)
                 time_len = len(label) - len(stripped_fact.serialized_name())
                 self.activity.select_region(0, time_len - 1)
-            buf = gtk.TextBuffer()
-            buf.set_text(original_fact.description or "")
-            self.description_box.set_buffer(buf)
+            self.description_buffer.set_text(original_fact.description or "")
 
         self.activity.original_fact = original_fact
 

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -197,7 +197,6 @@ class CustomFactController(gobject.GObject):
                              <i>description box</i>:
                              '''{}'''
                              """).format(escaped_cmd, escaped_box)
-            print(dedent(tooltip))
             self.update_status(looks_good=False,
                                markup=tooltip)
             return None

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -61,13 +61,15 @@ class CustomFactController(gobject.GObject):
         self.description_buffer = self.description_box.get_buffer()
         self.description_buffer.connect("changed", self.on_description_changed)
 
+        self.save_button = self.get_widget("save_button")
+
         self.activity.grab_focus()
         if fact_id:
             # editing
             fact = runtime.storage.get_fact(fact_id)
             self.date = fact.date
             original_fact = fact
-            self.get_widget("save_button").set_label("gtk-save")
+            self.save_button.set_label("gtk-save")
             self.window.set_title(_("Update activity"))
         else:
             self.date = hamster_today()
@@ -155,7 +157,7 @@ class CustomFactController(gobject.GObject):
         position = gtk.EntryIconPosition.SECONDARY
         self.activity.set_icon_from_icon_name(position, icon_name)
         self.activity.set_icon_tooltip_markup(position, markup)
-        self.get_widget("save_button").set_sensitive(looks_good)
+        self.save_button.set_sensitive(looks_good)
 
     def validate_fields(self):
         """Check fields information.

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -56,6 +56,8 @@ class CustomFactController(gobject.GObject):
         self.dayline = widgets.DayLine()
         self._gui.get_object("day_preview").add(self.dayline)
 
+        self.description_box = self.get_widget('description')
+
         self.activity.grab_focus()
         if fact_id:
             # editing
@@ -86,7 +88,7 @@ class CustomFactController(gobject.GObject):
                 self.activity.select_region(0, time_len - 1)
             buf = gtk.TextBuffer()
             buf.set_text(original_fact.description or "")
-            self.get_widget('description').set_buffer(buf)
+            self.description_box.set_buffer(buf)
 
         self.activity.original_fact = original_fact
 
@@ -116,7 +118,7 @@ class CustomFactController(gobject.GObject):
 
 
     def figure_description(self):
-        buf = self.get_widget('description').get_buffer()
+        buf = self.description_box.get_buffer()
         description = buf.get_text(buf.get_start_iter(), buf.get_end_iter(), 0)
         return description.strip()
 
@@ -188,7 +190,7 @@ class CustomFactController(gobject.GObject):
         elif event_key.keyval in (gdk.KEY_Return, gdk.KEY_KP_Enter):
             if popups:
                 return False
-            if self.get_widget('description').has_focus():
+            if self.description_box.has_focus():
                 return False
             self.on_save_button_clicked(None)
 

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -167,11 +167,13 @@ class CustomFactController(gobject.GObject):
         now = hamster_now()
         self.get_widget("button-next-day").set_sensitive(self.date < now.date())
 
-        if self.date != now.date():
-            now = dt.datetime.combine(self.date, now.time())
+        if self.date == now.date():
+            default_dt = now
+        else:
+            default_dt = dt.datetime.combine(self.date, now.time())
 
-        self.draw_preview(fact.start_time or now,
-                          fact.end_time or now)
+        self.draw_preview(fact.start_time or default_dt,
+                          fact.end_time or default_dt)
 
         if fact.start_time is None:
             self.update_status(looks_good=False, markup="Missing start time")

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -108,7 +108,6 @@ class CustomFactController(gobject.GObject):
         day_facts = runtime.storage.get_facts(self.date, ongoing_days=31)
         self.dayline.plot(self.date, day_facts, start_time, end_time)
 
-
     def get_widget(self, name):
         """ skip one variable (huh) """
         return self._gui.get_object(name)
@@ -116,12 +115,10 @@ class CustomFactController(gobject.GObject):
     def show(self):
         self.window.show()
 
-
     def figure_description(self):
         buf = self.description_box.get_buffer()
         description = buf.get_text(buf.get_start_iter(), buf.get_end_iter(), 0)
         return description.strip()
-
 
     def localized_fact(self):
         """Make sure fact has the correct start_time."""
@@ -131,8 +128,6 @@ class CustomFactController(gobject.GObject):
         else:
             fact.start_time = hamster_now()
         return fact
-
-
 
     def on_save_button_clicked(self, button):
         fact = self.localized_fact()
@@ -166,7 +161,6 @@ class CustomFactController(gobject.GObject):
         self.get_widget("save_button").set_sensitive(looks_good)
         return looks_good
 
-
     def on_delete_clicked(self, button):
         runtime.storage.remove_fact(self.fact_id)
         self.close_window()
@@ -193,8 +187,6 @@ class CustomFactController(gobject.GObject):
             if self.description_box.has_focus():
                 return False
             self.on_save_button_clicked(None)
-
-
 
     def close_window(self):
         if not self.parent:

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -411,6 +411,7 @@ class ActivityEntry(gtk.Entry):
                 variant_fact.end_time = None
 
             if variant_fact:
+                variant_fact.description = None
                 variant = variant_fact.serialized(prepend_date=False)
                 variants.append((description, variant))
 


### PR DESCRIPTION
Allow entering description 
either from the activity line or from the description box,
but not both (fix issue #305).
Prevent saving and give warning in case of ambiguity.

In activity line only, "valid" check mark icon to the right
![Screenshot_20190820_121643](https://user-images.githubusercontent.com/10962809/63339067-6028f480-c344-11e9-9042-5d0109ea8d6f.png)

Both in activity line and in description box: ambiguity (which one to use ?),
"error" check mark icon
![Screenshot_20190820_121902](https://user-images.githubusercontent.com/10962809/63339224-b8f88d00-c344-11e9-911c-baf4872130d7.png)
More information in the icon tooltip (hovering mouse on the icon)
![Screenshot_20190820_122124](https://user-images.githubusercontent.com/10962809/63339383-096fea80-c345-11e9-8c4f-e4011c534d64.png)

In description box (multiple lines allowed there), 
"valid" check mark icon
![Screenshot_20190820_122457](https://user-images.githubusercontent.com/10962809/63339586-8602c900-c345-11e9-9bee-97e184ddc4ab.png)

When editing an existing fact, the description is now only displayed in its box.
