### PR TITLE
Always update hover_fact

### DIFF
--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -377,7 +377,9 @@ class Storage(storage.Storage):
 
         facts = self.fetchall(query, (self._unsorted_localized, id))
         assert len(facts) > 0, "No fact with id {}".format(id)
-        return self.__group_tags(facts)[0]
+        fact = self.__group_tags(facts)[0]
+        logger.info("got fact {}".format(fact))
+        return fact
 
     def __group_tags(self, facts):
         """put the fact back together and move all the unique tags to an array"""

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -374,7 +374,9 @@ class Storage(storage.Storage):
                  ORDER BY e.name
         """
 
-        return self.__group_tags(self.fetchall(query, (self._unsorted_localized, id)))[0]
+        facts = self.fetchall(query, (self._unsorted_localized, id))
+        assert len(facts) > 0, "No fact with id {}".format(id)
+        return self.__group_tags(facts)[0]
 
     def __group_tags(self, facts):
         """put the fact back together and move all the unique tags to an array"""

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -67,7 +67,7 @@ class Storage(storage.Storage):
 
 
         self.db_path = self.__init_db_file(database_dir)
-        logger.debug(self.db_path)
+        logger.info("database: '{}'".format(self.db_path))
 
         if gio:
             # add file monitoring so the app does not have to be restarted
@@ -79,12 +79,13 @@ class Storage(storage.Storage):
                                            gio.FileQueryInfoFlags.NONE,
                                            None).get_etag() == self.__last_etag:
                         # ours
+                        logger.info("database updated")
                         return
                 elif event == gio.FileMonitorEvent.DELETED:
                     self.con = None
 
                 if event == gio.FileMonitorEvent.CHANGES_DONE_HINT:
-                    print("DB file has been modified externally. Calling all stations")
+                    logger.warning("DB file has been modified externally. Calling all stations")
                     self.dispatch_overwrite()
 
             self.__database_file = gio.File.new_for_path(self.db_path)
@@ -110,7 +111,7 @@ class Storage(storage.Storage):
         new_db_file = os.path.join(database_dir, "hamster.db")
         if os.path.exists(old_db_file):
             if os.path.exists(new_db_file):
-                logger.info("Have two database %s and %s" % (new_db_file, old_db_file))
+                logger.warning("Have two database %s and %s" % (new_db_file, old_db_file))
             else:
                 os.rename(old_db_file, new_db_file)
 
@@ -134,7 +135,7 @@ class Storage(storage.Storage):
 
             data_dir = os.path.realpath(data_dir)
 
-            logger.info("Database not found in %s - installing default from %s!" % (db_path, data_dir))
+            logger.warning("Database not found in %s - installing default from %s!" % (db_path, data_dir))
             copyfile(os.path.join(data_dir, 'hamster.db'), db_path)
 
             #change also permissions - sometimes they are 444

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -525,6 +525,8 @@ class Storage(storage.Storage):
                     start_time = start_time,
                     end_time = end_time)
 
+        logger.info("adding fact {}".format(fact))
+
         start_time = start_time or fact.start_time
         end_time = end_time or fact.end_time
 
@@ -622,6 +624,7 @@ class Storage(storage.Storage):
         self.execute(insert, params)
 
         self.__remove_index([fact_id])
+        logger.info("fact successfully added, with id #{}".format(fact_id))
         return fact_id
 
     def __last_insert_rowid(self):
@@ -742,6 +745,7 @@ class Storage(storage.Storage):
         return res
 
     def __remove_fact(self, fact_id):
+        logger.info("removing fact #{}".format(fact_id))
         statements = ["DELETE FROM fact_tags where fact_id = ?",
                       "DELETE FROM facts where id = ?"]
         self.execute(statements, [(fact_id,)] * 2)
@@ -841,8 +845,8 @@ class Storage(storage.Storage):
         """remove affected ids from the index"""
         if not ids:
             return
-
         ids = ",".join((str(id) for id in ids))
+        logger.info("removing fact #{} from index".format(ids))
         self.execute("DELETE FROM fact_index where id in (%s)" % ids)
 
 

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -321,6 +321,7 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         return facts_ids.index(self.current_fact.id)
 
     def on_mouse_down(self, scene, event):
+        self.on_mouse_move(None, event)
         self.grab_focus()
         if self.hover_fact:
             if self.hover_fact == self.current_fact:

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -343,26 +343,30 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         # all keys should appear also in the Overview.on_key_press
         # to be forwarded here even without focus.
         if event.keyval == gdk.KEY_Up:
-            if self.current_fact:
-                idx = max(0, self.current_fact_index - 1)
-            else:
-                # enter from below
-                idx = len(self.facts) - 1
-            self.set_current_fact(self.facts[idx])
+            if self.facts:
+                if self.current_fact:
+                    idx = max(0, self.current_fact_index - 1)
+                else:
+                    # enter from below
+                    idx = len(self.facts) - 1
+                self.set_current_fact(self.facts[idx])
 
         elif event.keyval == gdk.KEY_Down:
-            if self.current_fact:
-                idx = min(len(self.facts) - 1, self.current_fact_index + 1)
-            else:
-                # enter from top
-                idx = 0
-            self.set_current_fact(self.facts[idx])
+            if self.facts:
+                if self.current_fact:
+                    idx = min(len(self.facts) - 1, self.current_fact_index + 1)
+                else:
+                    # enter from top
+                    idx = 0
+                self.set_current_fact(self.facts[idx])
 
         elif event.keyval == gdk.KEY_Home:
-            self.set_current_fact(self.facts[0])
+            if self.facts:
+                self.set_current_fact(self.facts[0])
 
         elif event.keyval == gdk.KEY_End:
-            self.set_current_fact(self.facts[-1])
+            if self.facts:
+                self.set_current_fact(self.facts[-1])
 
         elif event.keyval == gdk.KEY_Page_Down:
             self.y += self.height * 0.8

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -240,12 +240,15 @@ class FactRow(object):
 
 class FactTree(graphics.Scene, gtk.Scrollable):
     """
-    The fact tree is a painter - it maintains scroll state and shows what we can
-    see. That means it does not show all the facts there are, but rather only
-    those that you can see.
-    It's also painter as it reuses labels. Caching is futile, we do all the painting
-    every time
+    The fact tree is a painter.
+    It does not change facts by itself, only sends signals.
+    Facts get updated only through `set_facts`.
 
+    It maintains scroll state and shows what we can see.
+    That means it does not show all the facts there are,
+    but rather only those that you can see.
+    It's also painter as it reuses labels.
+    Caching is futile, we do all the painting every time
 
 
     ASCII Art!
@@ -324,7 +327,6 @@ class FactTree(graphics.Scene, gtk.Scrollable):
                 self.unset_current_fact()
             else:
                 self.set_current_fact(self.hover_fact)
-
 
     def activate_row(self, day, fact):
         self.emit("on-activate-row", day, fact)
@@ -413,8 +415,12 @@ class FactTree(graphics.Scene, gtk.Scrollable):
                 break
 
         if hover_day != self.hover_day:
-            self.hover_day = hover_day
+            # Facts are considered equal if their content is the same,
+            # even if their id is different.
+            # redraw only cares about content, not id.
             self.redraw()
+        # make sure it is always fully updated, including facts ids.
+        self.hover_day = hover_day
 
         if self.hover_day:
             for fact in self.hover_day.get('facts', []):
@@ -423,8 +429,9 @@ class FactTree(graphics.Scene, gtk.Scrollable):
                     break
 
         if hover_fact != self.hover_fact:
-            self.hover_fact = hover_fact
             self.move_actions()
+        # idem, always update hover_fact, not just if they appear different
+        self.hover_fact = hover_fact
 
     def move_actions(self):
         if self.hover_fact:


### PR DESCRIPTION
Solves #431.
That seems to work fine, but is not entirely satisfying.
Calling `on_mouse_move` from `on_mouse_down` simulates a mouse move before clicking.
It feels a bit like a hack, but it was not easy to bring the common code to another function,
because of the current structure.

As a note for future development (certainly not just before v3.0 !),
since Facttree is a painter only (more details added to inline comments),
we could get rid of `self.hover_day` and `self.hover_fact`,
and use a property `self.hover_index` that would give the index of the hovered fact
into the `self.facts` list.
That property would use a new `self._mouse_y` that would be updated in `on_mouse_move`,
or `on_mouse_down`.
All  `on_mouse_move` would do is updating `self._mouse_y`.

Another `IndexError` is fixed by 16981e2