### PR TITLE
Fix dates

### DIFF
--- a/src/hamster-cli
+++ b/src/hamster-cli
@@ -218,7 +218,7 @@ class HamsterClient(object):
 
         start_time = start_time or dt.datetime.combine(dt.date.today(), dt.time())
         end_time = end_time or start_time.replace(hour=23, minute=59, second=59)
-        facts = self.storage.get_facts(start_time, end_time, ongoing_days=31)
+        facts = self.storage.get_facts(start_time, end_time)
 
         writer = reports.simple(facts, start_time.date(), end_time.date(), export_format)
 
@@ -284,7 +284,7 @@ class HamsterClient(object):
 
     def _list(self, start_time, end_time, search=""):
         """Print a listing of activities"""
-        facts = self.storage.get_facts(start_time, end_time, search, ongoing_days=31)
+        facts = self.storage.get_facts(start_time, end_time, search)
 
 
         headers = {'activity': _("Activity"),

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -109,7 +109,12 @@ class Storage(gobject.GObject):
         """
         return [from_dbus_fact(fact) for fact in self.conn.GetTodaysFacts()]
 
-    def _get_facts(self, date, end_date=None, search_terms=""):
+    def get_facts(self, date, end_date=None, search_terms=""):
+        """Returns facts for the time span matching the optional filter criteria.
+           In search terms comma (",") translates to boolean OR and space (" ")
+           to boolean AND.
+           Filter is applied to tags, categories, activity names and description
+        """
         date = timegm(date.timetuple())
         end_date = end_date or 0
         if end_date:
@@ -117,25 +122,6 @@ class Storage(gobject.GObject):
         return [from_dbus_fact(fact) for fact in self.conn.GetFacts(date,
                                                                     end_date,
                                                                     search_terms)]
-
-    def get_facts(self, date, end_date=None, search_terms="", ongoing_days=0):
-        """Returns facts for the time span matching the optional filter criteria.
-           In search terms comma (",") translates to boolean OR and space (" ")
-           to boolean AND.
-           Filter is applied to tags, categories, activity names and description
-           ongoing_days (int): look into the last `ongoing_days` days
-                               for still ongoing activities
-        """
-        facts = []
-        if ongoing_days:
-            # look for still ongoing activities
-            earlier_start = date - dt.timedelta(days=ongoing_days)
-            earlier_end = date - dt.timedelta(days=1)
-            earlier_facts = self._get_facts(earlier_start, earlier_end, search_terms=search_terms)
-            facts.extend(fact for fact in earlier_facts if not fact.end_time)
-        # add facts between date and end_date
-        facts.extend(self._get_facts(date, end_date, search_terms=search_terms))
-        return facts
 
     def get_activities(self, search = ""):
         """returns list of activities name matching search criteria.

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -178,7 +178,7 @@ class CustomFactController(gobject.GObject):
             self.update_status(looks_good=False, markup="Missing start time")
             return None
 
-        if fact.activity is None:
+        if not fact.activity:
             self.update_status(looks_good=False, markup="Missing activity")
             return None
 

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -113,7 +113,7 @@ class CustomFactController(gobject.GObject):
         self.validate_fields()
 
     def draw_preview(self, start_time, end_time=None):
-        day_facts = runtime.storage.get_facts(self.date, ongoing_days=31)
+        day_facts = runtime.storage.get_facts(self.date)
         self.dayline.plot(self.date, day_facts, start_time, end_time)
 
     def get_widget(self, name):

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -74,13 +74,9 @@ class CustomFactController(gobject.GObject):
             self.date = hamster_today()
             self.get_widget("delete_button").set_sensitive(False)
             if base_fact:
-                # cloning
-                original_fact = base_fact.copy()
-                # start running now.
-                # Do not try to pass end_time=None to copy(), above;
-                # it would be discarded.
-                original_fact.start_time = hamster_now()
-                original_fact.end_time = None
+                # start a clone now.
+                original_fact = base_fact.copy(start_time=hamster_now(),
+                                               end_time=None)
             else:
                 original_fact = None
 

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -5,6 +5,8 @@ import calendar
 import datetime as dt
 import re
 
+from copy import deepcopy
+
 from hamster.lib.stuff import (
     datetime_to_hamsterday,
     hamsterday_time_to_datetime,
@@ -147,7 +149,9 @@ class Fact(object):
         By default, only copy user-visible attributes.
         To also copy the id, use fact.copy(id=fact.id)
         """
-        return Fact(initial_fact=self, **kwds)
+        fact = deepcopy(self)
+        fact._set(**kwds)
+        return fact
 
     @property
     def date(self):
@@ -207,6 +211,19 @@ class Fact(object):
         name = self.serialized_name()
         datetime = self.serialized_time(prepend_date)
         return "%s %s" % (datetime, name)
+
+    def _set(self, **kwds):
+        """Modify attributes.
+
+        Private, used only in copy. It is more readable to be explicit, e.g.:
+        fact.start_time = ...
+        fact.end_time = ...
+        """
+        for attr, value in kwds.items():
+            if not hasattr(self, attr):
+                raise AttributeError(f"'{attr}' not found")
+            else:
+                setattr(self, attr, value)
 
     def __eq__(self, other):
         return (id(self) == id(other)

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -175,7 +175,7 @@ class Fact(object):
         return end_time - self.start_time
 
     def serialized_name(self):
-        res = self.activity
+        res = self.activity or ""
 
         if self.category:
             res += "@%s" % self.category

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -164,8 +164,13 @@ class Fact(object):
     @date.setter
     def date(self, value):
         if self.start_time:
+            previous_start_time = self.start_time
             self.start_time = hamsterday_time_to_datetime(value, self.start_time.time())
-        if self.end_time:
+            if self.end_time:
+                # start_time date prevails.
+                # Shift end_time to preserve the fact duration.
+                self.end_time += self.start_time - previous_start_time
+        elif self.end_time:
             self.end_time = hamsterday_time_to_datetime(value, self.end_time.time())
 
     @property

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -525,7 +525,7 @@ class Overview(Controller):
         search_active = self.header_bar.search_button.get_active()
         search = "" if not search_active else self.filter_entry.get_text()
         search = "%s*" % search if search else "" # search anywhere
-        self.facts = self.storage.get_facts(start, end, search_terms=search, ongoing_days=31)
+        self.facts = self.storage.get_facts(start, end, search_terms=search)
         self.fact_tree.set_facts(self.facts)
         self.totals.set_facts(self.facts)
 

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -734,8 +734,8 @@ class Storage(storage.Storage):
                 # (in which case we give up)
                 fact_date = fact_start_date
 
-            if fact_date < date or fact_date > end_date:
-                # due to spanning we've jumped outside of given period
+            if fact["start_time"] < datetime_from - dt.timedelta(days=30):
+                # ignoring old on-going facts
                 continue
 
             fact["date"] = fact_date

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -641,7 +641,7 @@ class Storage(storage.Storage):
         datetime_from = dt.datetime.combine(date, split_time)
 
         end_date = end_date or date
-        datetime_to = dt.datetime.combine(end_date, split_time) + dt.timedelta(days = 1)
+        datetime_to = dt.datetime.combine(end_date, split_time) + dt.timedelta(days=1, seconds=-1)
 
         logger.info("searching for facts from {} to {}".format(datetime_from, datetime_to))
 

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -659,6 +659,8 @@ class Storage(storage.Storage):
         end_date = end_date or date
         datetime_to = dt.datetime.combine(end_date, split_time) + dt.timedelta(days = 1)
 
+        logger.info("searching for facts from {} to {}".format(datetime_from, datetime_to))
+
         query = """
                    SELECT a.id AS id,
                           a.start_time AS start_time,

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -47,7 +47,9 @@ except ImportError:
     gio = None
 
 from hamster.lib import Fact
+from hamster.lib.configuration import conf
 from hamster.lib.stuff import hamster_today, hamster_now
+
 
 
 class Storage(storage.Storage):
@@ -632,28 +634,10 @@ class Storage(storage.Storage):
 
 
     def __get_todays_facts(self):
-        try:
-            from hamster.lib.configuration import conf
-            day_start = conf.day_start
-        except:
-            day_start = dt.time(5, 0)  # default: 5:00
-        today = (hamster_now() - dt.timedelta(hours=day_start.hour,
-                                              minutes=day_start.minute)).date()
-        return self.__get_facts(today)
-
+        return self.__get_facts(hamster_today())
 
     def __get_facts(self, date, end_date = None, search_terms = ""):
-        try:
-            from hamster.lib.configuration import conf
-            day_start = conf.get("day_start_minutes")
-            day_start_h, day_start_m = divmod(day_start)
-        except:
-            # default day start to 5am
-            day_start_h = 5
-            day_start_m = 0
-        day_start = dt.time(day_start_h, day_start_m)
-
-        split_time = day_start
+        split_time = conf.day_start
         datetime_from = dt.datetime.combine(date, split_time)
 
         end_date = end_date or date

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -293,7 +293,7 @@ class ActivityEntry(gtk.Entry):
         suggestions = defaultdict(int)
         for fact in last_month:
             days = 30 - (now - dt.datetime.combine(fact.date, dt.time())).total_seconds() / 60 / 60 / 24
-            label = fact.activity
+            label = fact.activity or ""
             if fact.category:
                 label += "@%s" % fact.category
 

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -152,7 +152,7 @@ class FactRow(object):
             time_label += fact.end_time.strftime(" %H:%M")
         self.time_label.set_text(time_label)
 
-        self.activity_label.set_text(stuff.escape_pango(fact.activity))
+        self.activity_label.set_text(stuff.escape_pango(fact.activity or ""))
 
         category_text = "  - {}".format(stuff.escape_pango(fact.category)) if fact.category else ""
         self.category_label.set_text(category_text)

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -102,6 +102,24 @@ class TestActivityInputParsing(unittest.TestCase):
         self.assertEqual(activity.description, "description #ta non-tag")
         self.assertEqual(set(activity.tags), set(["bäg", "tag"]))
 
+    def test_copy(self):
+        fact1 = Fact("12:25-13:25 case@cat, description #tag #bäg")
+        fact2 = fact1.copy()
+        self.assertEqual(fact1.start_time, fact2.start_time)
+        self.assertEqual(fact1.end_time, fact2.end_time)
+        self.assertEqual(fact1.activity, fact2.activity)
+        self.assertEqual(fact1.category, fact2.category)
+        self.assertEqual(fact1.description, fact2.description)
+        self.assertEqual(fact1.tags, fact2.tags)
+        fact3 = fact1.copy(activity="changed")
+        self.assertEqual(fact3.activity, "changed")
+        fact3 = fact1.copy(category="changed")
+        self.assertEqual(fact3.category, "changed")
+        fact3 = fact1.copy(description="changed")
+        self.assertEqual(fact3.description, "changed")
+        fact3 = fact1.copy(tags=["changed"])
+        self.assertEqual(fact3.tags, ["changed"])
+
     def test_initial_fact(self):
         fact = Fact("12:25-13:25 case@cat, description #tag #bäg")
         fact_copy = Fact(initial_fact=fact)


### PR DESCRIPTION
This hopefully fixes date-related issues

In particular #419 is solved by using a clear rule rather than heuristics:
for activities overlapping the hamster day-start time, use
the selected hamster-day for start_time
(since it is an early morning start, this corresponds to the next civil date), 
and the next date for end_time.
A warning informs the user that something unusual is happening,
and gives full information to check:

![image](https://user-images.githubusercontent.com/10962809/63801839-82f17500-c911-11e9-8a79-01481676a018.png)
The displayed duration is correct (not "negative" any longer).

If the fact is to be created in the past, the selected date has to be decremented.
It is much safer to create the next civil day by default, since chances for conflicts is reduced.

Note that now the overlapping fact is displayed for the selected hamster-days (26th here),
because part of its activity belongs to the 26th.
Its indicated date is the start-time hamster-day.

Bonus: on-going facts from the month before displayed dates are now shown without the need
for a second search.
