### PR TITLE
Verbatim database reading

### DIFF
--- a/src/hamster-cli
+++ b/src/hamster-cli
@@ -319,7 +319,7 @@ class HamsterClient(object):
 
         by_cat = {}
         for fact in facts:
-            cat = fact.category or _("Uncategorized")
+            cat = fact.category or _("Unsorted")
             by_cat.setdefault(cat, dt.timedelta(0))
             by_cat[cat] += fact.delta
 

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -27,7 +27,7 @@ from hamster.lib import Fact, hamster_now
 
 def from_dbus_fact(fact):
     """unpack the struct into a proper dict"""
-    return Fact(fact[4],
+    return Fact(activity=fact[4],
                 start_time  = dt.datetime.utcfromtimestamp(fact[1]),
                 end_time = dt.datetime.utcfromtimestamp(fact[2]) if fact[2] else None,
                 description = fact[3],

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -25,17 +25,19 @@ import dbus, dbus.mainloop.glib
 from gi.repository import GObject as gobject
 from hamster.lib import Fact, hamster_now
 
+
 def from_dbus_fact(fact):
     """unpack the struct into a proper dict"""
     return Fact(activity=fact[4],
-                start_time  = dt.datetime.utcfromtimestamp(fact[1]),
-                end_time = dt.datetime.utcfromtimestamp(fact[2]) if fact[2] else None,
-                description = fact[3],
-                activity_id = fact[5],
-                category = fact[6],
-                tags = fact[7],
-            id = fact[0]
-            )
+                start_time=dt.datetime.utcfromtimestamp(fact[1]),
+                end_time=dt.datetime.utcfromtimestamp(fact[2]) if fact[2] else None,
+                description=fact[3],
+                activity_id=fact[5],
+                category=fact[6],
+                tags=fact[7],
+                id=fact[0]
+                )
+
 
 class Storage(gobject.GObject):
     """Hamster client class, communicating to hamster storage daemon via d-bus.

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -34,7 +34,6 @@ def from_dbus_fact(fact):
                 activity_id = fact[5],
                 category = fact[6],
                 tags = fact[7],
-                date = dt.datetime.utcfromtimestamp(fact[8]).date(),
             id = fact[0]
             )
 

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -125,7 +125,7 @@ class CustomFactController(gobject.GObject):
 
     def localized_fact(self):
         """Make sure fact has the correct start_time."""
-        fact = Fact(self.activity.get_text())
+        fact = Fact.parse(self.activity.get_text())
         if fact.start_time:
             fact.date = self.date
         else:

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -88,7 +88,7 @@ class CustomFactController(gobject.GObject):
                 self.activity.set_text(label)
                 time_len = len(label) - len(stripped_fact.serialized_name())
                 self.activity.select_region(0, time_len - 1)
-            self.description_buffer.set_text(original_fact.description or "")
+            self.description_buffer.set_text(original_fact.description)
 
         self.activity.original_fact = original_fact
 

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -87,7 +87,7 @@ class Fact(object):
                   (only for very specific direct database read/write)
         """
 
-        self.activity = activity or ""
+        self.activity = activity
         self.category = category.replace(",", "").strip() if category else None
         self.description = description.strip() if description else None
         self.tags = tags or []
@@ -110,6 +110,15 @@ class Fact(object):
             'end_time': self.end_time if isinstance(self.end_time, str) else calendar.timegm(self.end_time.timetuple()) if self.end_time else "",
             'delta': self.delta.total_seconds()  # ugly, but needed for report.py
         }
+
+    @property
+    def activity(self):
+        """Activity name."""
+        return self._activity
+
+    @activity.setter
+    def activity(self, value):
+        self._activity = value.strip() if value else ""
 
     def copy(self, **kwds):
         """Return an independent copy, with overrides as keyword arguments.
@@ -161,7 +170,7 @@ class Fact(object):
         return fact
 
     def serialized_name(self):
-        res = self.activity or ""
+        res = self.activity
 
         if self.category:
             res += "@%s" % self.category

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -74,8 +74,7 @@ def figure_time(str_time):
 
 class Fact(object):
     def __init__(self, activity="", category=None, description=None, tags=None,
-                 start_time=None, end_time=None, id=None,
-                 date=None, activity_id=None):
+                 start_time=None, end_time=None, id=None, activity_id=None):
         """Homogeneous chunk of activity.
 
         The category, description and tags must be passed explicitly.
@@ -154,7 +153,8 @@ class Fact(object):
 
     @classmethod
     def parse(cls, string, date=None):
-        fact = Fact(date=date)
+        fact = Fact()
+        fact.date = date
         phase = "start_time" if date else "date"
         for key, val in parse_fact(string, phase, {}, date).items():
             setattr(fact, key, val)

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -89,7 +89,7 @@ class Fact(object):
 
         self.activity = activity
         self.category = category
-        self.description = description.strip() if description else None
+        self.description = description
         self.tags = tags or []
         self.start_time = start_time
         self.end_time = end_time
@@ -167,6 +167,14 @@ class Fact(object):
         """Duration (datetime.timedelta)."""
         end_time = self.end_time if self.end_time else hamster_now()
         return end_time - self.start_time
+
+    @property
+    def description(self):
+        return self._description
+
+    @description.setter
+    def description(self, value):
+        self._description = value.strip() if value else ""
 
     @classmethod
     def parse(cls, string, date=None):

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -88,7 +88,7 @@ class Fact(object):
         """
 
         self.activity = activity
-        self.category = category.replace(",", "").strip() if category else None
+        self.category = category
         self.description = description.strip() if description else None
         self.tags = tags or []
         self.start_time = start_time
@@ -119,6 +119,14 @@ class Fact(object):
     @activity.setter
     def activity(self, value):
         self._activity = value.strip() if value else ""
+
+    @property
+    def category(self):
+        return self._category
+
+    @category.setter
+    def category(self, value):
+        self._category = value.replace(",", "").strip() if value else ""
 
     def copy(self, **kwds):
         """Return an independent copy, with overrides as keyword arguments.

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -497,7 +497,7 @@ class Storage(storage.Storage):
                 fact_name = fact["name"]
 
                 # create new fact for the end
-                new_fact = Fact(fact["name"],
+                new_fact = Fact(activity=fact["name"],
                                 category = fact["category"],
                                 description = fact["description"])
                 new_fact_id = self.__add_fact(new_fact.serialized_name(), end_time, fact_end_time)
@@ -523,9 +523,9 @@ class Storage(storage.Storage):
 
 
     def __add_fact(self, serialized_fact, start_time, end_time = None, temporary = False):
-        fact = Fact(serialized_fact,
-                    start_time = start_time,
-                    end_time = end_time)
+        fact = Fact.parse(serialized_fact)
+        fact.start_time = start_time
+        fact.end_time = end_time
 
         logger.info("adding fact {}".format(fact))
 

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -39,11 +39,19 @@ class Storage(object):
 
     # facts
     def add_fact(self, fact, start_time, end_time, temporary = False):
-        fact = Fact(fact, start_time = start_time, end_time = end_time)
-        start_time = fact.start_time or hamster_now()
+        """Add fact.
+
+        fact: either a Fact instance or
+              a string that can be parsed through Fact.parse.
+        """
+        if isinstance(fact, Fact):
+            fact_str = fact.serialized_name()
+        else:
+            fact_str = fact
+        start_time = start_time or hamster_now()
 
         self.start_transaction()
-        result = self.__add_fact(fact.serialized_name(), start_time, end_time, temporary)
+        result = self.__add_fact(fact_str, start_time, end_time, temporary)
         self.end_transaction()
 
         if result:

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -42,7 +42,7 @@ from hamster.lib import graphics
 
 
 def extract_search(text):
-    fact = Fact(text)
+    fact = Fact.parse(text)
     search = fact.activity or ""
     if fact.category:
         search += "@%s" % fact.category
@@ -314,7 +314,8 @@ class ActivityEntry(gtk.Entry):
 
     def complete_first(self):
         text = self.get_text()
-        fact, search = Fact(text), extract_search(text)
+        fact = Fact.parse(text)
+        search = extract_search(text)
         if not self.complete_tree.rows or not fact.activity:
             return text, None
 
@@ -349,7 +350,7 @@ class ActivityEntry(gtk.Entry):
 
         res = []
 
-        fact = Fact(text)
+        fact = Fact.parse(text)
         now = stuff.hamster_now()
 
         # figure out what we are looking for

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -43,7 +43,7 @@ from hamster.lib import graphics
 
 def extract_search(text):
     fact = Fact.parse(text)
-    search = fact.activity or ""
+    search = fact.activity
     if fact.category:
         search += "@%s" % fact.category
     if fact.tags:
@@ -293,7 +293,7 @@ class ActivityEntry(gtk.Entry):
         suggestions = defaultdict(int)
         for fact in last_month:
             days = 30 - (now - dt.datetime.combine(fact.date, dt.time())).total_seconds() / 60 / 60 / 24
-            label = fact.activity or ""
+            label = fact.activity
             if fact.category:
                 label += "@%s" % fact.category
 

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -152,7 +152,7 @@ class FactRow(object):
             time_label += fact.end_time.strftime(" %H:%M")
         self.time_label.set_text(time_label)
 
-        self.activity_label.set_text(stuff.escape_pango(fact.activity or ""))
+        self.activity_label.set_text(stuff.escape_pango(fact.activity))
 
         category_text = "  - {}".format(stuff.escape_pango(fact.category)) if fact.category else ""
         self.category_label.set_text(category_text)

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -37,7 +37,7 @@ class TestActivityInputParsing(unittest.TestCase):
         assert activity.start_time is None
         assert activity.end_time is None
         assert not activity.category
-        assert activity.description is None
+        assert not activity.description
 
     def test_with_start_time(self):
         # with time
@@ -48,7 +48,7 @@ class TestActivityInputParsing(unittest.TestCase):
         #rest must be empty
         assert not activity.category
         assert activity.end_time is None
-        assert activity.description is None
+        assert not activity.description
 
     def test_with_start_and_end_time(self):
         # with time
@@ -59,7 +59,7 @@ class TestActivityInputParsing(unittest.TestCase):
 
         #rest must be empty
         assert not activity.category
-        assert activity.description is None
+        assert not activity.description
 
     def test_category(self):
         # plain activity name
@@ -68,7 +68,7 @@ class TestActivityInputParsing(unittest.TestCase):
         self.assertEqual(activity.category, "hämster")
         assert activity.start_time is None
         assert activity.end_time is None
-        assert activity.description is None
+        assert not activity.description
 
     def test_description(self):
         # plain activity name
@@ -164,7 +164,7 @@ class TestActivityInputParsing(unittest.TestCase):
         fact = Fact.parse("11:00 12:00 BPC-261 - Task title@Project#code")
         self.assertEqual(fact.activity, "BPC-261 - Task title")
         self.assertEqual(fact.category, "Project")
-        self.assertEqual(fact.description, None)
+        self.assertEqual(fact.description, "")
         self.assertEqual(fact.tags, ["code"])
         # space between category and tag
         fact2 = Fact.parse("11:00 12:00 BPC-261 - Task title@Project #code")

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -32,7 +32,7 @@ class TestActivityInputParsing(unittest.TestCase):
 
     def test_plain_name(self):
         # plain activity name
-        activity = Fact("just a simple case with ütf-8")
+        activity = Fact.parse("just a simple case with ütf-8")
         self.assertEqual(activity.activity, "just a simple case with ütf-8")
 
         assert activity.category is None
@@ -43,7 +43,7 @@ class TestActivityInputParsing(unittest.TestCase):
 
     def test_with_start_time(self):
         # with time
-        activity = Fact("12:35 with start time")
+        activity = Fact.parse("12:35 with start time")
         self.assertEqual(activity.activity, "with start time")
         self.assertEqual(activity.start_time.strftime("%H:%M"), "12:35")
 
@@ -54,7 +54,7 @@ class TestActivityInputParsing(unittest.TestCase):
 
     def test_with_start_and_end_time(self):
         # with time
-        activity = Fact("12:35-14:25 with start-end time")
+        activity = Fact.parse("12:35-14:25 with start-end time")
         self.assertEqual(activity.activity, "with start-end time")
         self.assertEqual(activity.start_time.strftime("%H:%M"), "12:35")
         self.assertEqual(activity.end_time.strftime("%H:%M"), "14:25")
@@ -65,7 +65,7 @@ class TestActivityInputParsing(unittest.TestCase):
 
     def test_category(self):
         # plain activity name
-        activity = Fact("just a simple case@hämster")
+        activity = Fact.parse("just a simple case@hämster")
         self.assertEqual(activity.activity, "just a simple case")
         self.assertEqual(activity.category, "hämster")
         assert activity.start_time is None
@@ -74,7 +74,7 @@ class TestActivityInputParsing(unittest.TestCase):
 
     def test_description(self):
         # plain activity name
-        activity = Fact("case, with added descriptiön")
+        activity = Fact.parse("case, with added descriptiön")
         self.assertEqual(activity.activity, "case")
         self.assertEqual(activity.description, "with added descriptiön")
         assert activity.category is None
@@ -84,7 +84,7 @@ class TestActivityInputParsing(unittest.TestCase):
 
     def test_tags(self):
         # plain activity name
-        activity = Fact("case, with added #de description #and, #some #tägs")
+        activity = Fact.parse("case, with added #de description #and, #some #tägs")
         self.assertEqual(activity.activity, "case")
         self.assertEqual(activity.description, "with added #de description")
         self.assertEqual(set(activity.tags), set(["and", "some", "tägs"]))
@@ -94,7 +94,7 @@ class TestActivityInputParsing(unittest.TestCase):
 
     def test_full(self):
         # plain activity name
-        activity = Fact("1225-1325 case@cat, description #ta non-tag #tag #bäg")
+        activity = Fact.parse("1225-1325 case@cat, description #ta non-tag #tag #bäg")
         self.assertEqual(activity.start_time.strftime("%H:%M"), "12:25")
         self.assertEqual(activity.end_time.strftime("%H:%M"), "13:25")
         self.assertEqual(activity.activity, "case")
@@ -103,7 +103,7 @@ class TestActivityInputParsing(unittest.TestCase):
         self.assertEqual(set(activity.tags), set(["bäg", "tag"]))
 
     def test_copy(self):
-        fact1 = Fact("12:25-13:25 case@cat, description #tag #bäg")
+        fact1 = Fact.parse("12:25-13:25 case@cat, description #tag #bäg")
         fact2 = fact1.copy()
         self.assertEqual(fact1.start_time, fact2.start_time)
         self.assertEqual(fact1.end_time, fact2.end_time)
@@ -120,18 +120,8 @@ class TestActivityInputParsing(unittest.TestCase):
         fact3 = fact1.copy(tags=["changed"])
         self.assertEqual(fact3.tags, ["changed"])
 
-    def test_initial_fact(self):
-        fact = Fact("12:25-13:25 case@cat, description #tag #bäg")
-        fact_copy = Fact(initial_fact=fact)
-        self.assertEqual(fact_copy.start_time.strftime("%H:%M"), "12:25")
-        self.assertEqual(fact_copy.end_time.strftime("%H:%M"), "13:25")
-        self.assertEqual(fact_copy.activity, "case")
-        self.assertEqual(fact_copy.category, "cat")
-        self.assertEqual(fact_copy.description, "description")
-        self.assertEqual(fact_copy.tags, ["tag", "bäg"])
-
     def test_comparison(self):
-        fact1 = Fact("12:25-13:25 case@cat, description #tag #bäg")
+        fact1 = Fact.parse("12:25-13:25 case@cat, description #tag #bäg")
         fact2 = fact1.copy()
         self.assertEqual(fact1, fact2)
         fact2 = fact1.copy()
@@ -161,25 +151,25 @@ class TestActivityInputParsing(unittest.TestCase):
 
     def test_decimal_in_activity(self):
         # cf. issue #270
-        fact = Fact("12:25-13:25 10.0@ABC, Two Words #tag #bäg")
+        fact = Fact.parse("12:25-13:25 10.0@ABC, Two Words #tag #bäg")
         self.assertEqual(fact.activity, "10.0")
         self.assertEqual(fact.category, "ABC")
         self.assertEqual(fact.description, "Two Words")
         # should not pick up a time here
-        fact = Fact("10.00@ABC, Two Words #tag #bäg")
+        fact = Fact.parse("10.00@ABC, Two Words #tag #bäg")
         self.assertEqual(fact.activity, "10.00")
         self.assertEqual(fact.category, "ABC")
         self.assertEqual(fact.description, "Two Words")
 
     def test_spaces(self):
         # cf. issue #114
-        fact = Fact("11:00 12:00 BPC-261 - Task title@Project#code")
+        fact = Fact.parse("11:00 12:00 BPC-261 - Task title@Project#code")
         self.assertEqual(fact.activity, "BPC-261 - Task title")
         self.assertEqual(fact.category, "Project")
         self.assertEqual(fact.description, None)
         self.assertEqual(fact.tags, ["code"])
         # space between category and tag
-        fact2 = Fact("11:00 12:00 BPC-261 - Task title@Project #code")
+        fact2 = Fact.parse("11:00 12:00 BPC-261 - Task title@Project #code")
         self.assertEqual(fact.serialized(), fact2.serialized())
 
 if __name__ == '__main__':

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -34,11 +34,9 @@ class TestActivityInputParsing(unittest.TestCase):
         # plain activity name
         activity = Fact.parse("just a simple case with ütf-8")
         self.assertEqual(activity.activity, "just a simple case with ütf-8")
-
-        assert activity.category is None
         assert activity.start_time is None
         assert activity.end_time is None
-        assert activity.category is None
+        assert not activity.category
         assert activity.description is None
 
     def test_with_start_time(self):
@@ -48,7 +46,7 @@ class TestActivityInputParsing(unittest.TestCase):
         self.assertEqual(activity.start_time.strftime("%H:%M"), "12:35")
 
         #rest must be empty
-        assert activity.category is None
+        assert not activity.category
         assert activity.end_time is None
         assert activity.description is None
 
@@ -60,7 +58,7 @@ class TestActivityInputParsing(unittest.TestCase):
         self.assertEqual(activity.end_time.strftime("%H:%M"), "14:25")
 
         #rest must be empty
-        assert activity.category is None
+        assert not activity.category
         assert activity.description is None
 
     def test_category(self):
@@ -77,10 +75,10 @@ class TestActivityInputParsing(unittest.TestCase):
         activity = Fact.parse("case, with added descriptiön")
         self.assertEqual(activity.activity, "case")
         self.assertEqual(activity.description, "with added descriptiön")
-        assert activity.category is None
+        assert not activity.category
         assert activity.start_time is None
         assert activity.end_time is None
-        assert activity.category is None
+        assert not activity.category
 
     def test_tags(self):
         # plain activity name
@@ -88,7 +86,7 @@ class TestActivityInputParsing(unittest.TestCase):
         self.assertEqual(activity.activity, "case")
         self.assertEqual(activity.description, "with added #de description")
         self.assertEqual(set(activity.tags), set(["and", "some", "tägs"]))
-        assert activity.category is None
+        assert not activity.category
         assert activity.start_time is None
         assert activity.end_time is None
 


### PR DESCRIPTION
Prior to this PR facts read from the database were serialized and parsed again.
With this PR facts are read verbatim from the database.
This is expected to partially solve issue #423,
and clarifies the code.

`activity`, `category` and `description` are now properties, with setters to sanitize them.
They are now guaranteed to be strings (empty meaning none).

Breaking change: 
`Fact(str)` has to be replaced by `Fact.parse(str)`