### PR TITLE
clarify Fact comparisons

### DIFF
--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -228,15 +228,13 @@ class Fact(object):
                 setattr(self, attr, value)
 
     def __eq__(self, other):
-        return (id(self) == id(other)
-                or (isinstance(other, Fact)
-                    and self.activity == other.activity
-                    and self.category == other.category
-                    and self.description == other.description
-                    and self.end_time == other.end_time
-                    and self.start_time == other.start_time
-                    and self.tags == other.tags
-                   )
+        return (isinstance(other, Fact)
+                and self.activity == other.activity
+                and self.category == other.category
+                and self.description == other.description
+                and self.end_time == other.end_time
+                and self.start_time == other.start_time
+                and self.tags == other.tags
                 )
 
     def __repr__(self):

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -324,7 +324,12 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         self.on_mouse_move(None, event)
         self.grab_focus()
         if self.hover_fact:
-            if self.hover_fact == self.current_fact:
+            # match either content or id
+            if (self.hover_fact == self.current_fact
+                or (self.hover_fact
+                    and self.current_fact
+                    and self.hover_fact.id == self.current_fact.id)
+               ):
                 self.unset_current_fact()
             else:
                 self.set_current_fact(self.hover_fact)
@@ -433,7 +438,10 @@ class FactTree(graphics.Scene, gtk.Scrollable):
                     hover_fact = fact
                     break
 
-        if hover_fact != self.hover_fact:
+        if (hover_fact
+            and self.hover_fact
+            and hover_fact.id != self.hover_fact.id
+           ):
             self.move_actions()
         # idem, always update hover_fact, not just if they appear different
         self.hover_fact = hover_fact


### PR DESCRIPTION
Base comparisons on fact elements only (id is ignored now).
The `or` introduced in 9dc0d96a11077ba3cc18f3c9316c5906bc5084ca was too much magic.
With this PR the reasoning about fact equalities is simplified.
`id` equality has now to be checked explicitly.
This is obviously a breaking change with respect to v2.2.1 which introduced fact comparisons
(precisely 3837ddcc1b1ce5c36377ac9b355c6f92cb06dbdc).