### PR TITLE
Relocate hamster.db to ~/.local/share/hamster-time-tracker

### DIFF
--- a/help/C/backup.page
+++ b/help/C/backup.page
@@ -9,7 +9,7 @@
 
 <p>
     Activities are stored in an SQLite database, located at
-    <file>~/.local/share/hamster-applet/hamster.db</file>.
+    <file>~/.local/share/hamster-time-tracker/hamster.db</file>.
     The file can be backed up and restored on the go.
     The application will reload the data automatically after a short while.
 </p>
@@ -19,4 +19,13 @@
         <link href="https://sqlitebrowser.org/"><app>DB Browser for SQLite (DB4S)</app></link>.
     </p>
 </note>
+<note style="info">
+    <p>
+        Previously the database was stored in
+        <file>~/.local/share/hamster-applet/hamster.db</file>.
+        Recent versions of Hamster migrate this file to the new location
+        and the old file can be safely removed afterwards if desired.
+    </p>
+</note>
+
 </page>

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -24,21 +24,11 @@
 import logging
 logger = logging.getLogger(__name__)   # noqa: E402
 
-try:
-    import sqlite3 as sqlite
-except ImportError:
-    try:
-        logger.warn("Using sqlite2")
-        from pysqlite2 import dbapi2 as sqlite
-    except ImportError:
-        logger.error("Neither sqlite3 nor pysqlite2 found")
-        raise
-
 import os, time
 import datetime
-from hamster.storage import storage
-from shutil import copy as copyfile
 import itertools
+import sqlite3 as sqlite
+from shutil import copy as copyfile
 import datetime as dt
 try:
     from gi.repository import Gio as gio
@@ -46,10 +36,10 @@ except ImportError:
     print("Could not import gio - requires pygobject. File monitoring will be disabled")
     gio = None
 
+from hamster.storage import storage
 from hamster.lib import Fact
 from hamster.lib.configuration import conf
 from hamster.lib.stuff import hamster_today, hamster_now
-
 
 
 class Storage(storage.Storage):


### PR DESCRIPTION
Revert from ~/.local/share/hamster-applet to ~/.local/share/hamster-time-tracker as default location for  hamster.db. In the long run this will be less confusing given that all other installation directories now use hamster-time-tracker and not hamster-applet.

In this proposal, at first startup of hamster-service, if an existing database found under xdg_data_home/hamster-applet and not under xdg_data_home/hamster-time-tracker, a hard link will be created such that the two files are one and the same. That way if the user has an ongoing backup strategy in place using the hamster-applet directory, it will continue to work. At any time after first startup the old location can be deleted if desired (just the link will be deleted, the database will remain in the new location).