### PR TITLE
Add Ubuntu build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,15 @@ pgrep -af hamster
 
 ##### Debian-based
 
-ubuntu (tested in 19.04 and 18.04):
+###### Ubuntu (tested in 19.04 and 18.04)
+Run-time:
 ```bash
 sudo apt install gettext intltool gconf2 gir1.2-gconf-2.0 python3-gi-cairo
 sudo apt install gnome-doc-utils yelp
+```
+Build:
+```bash
+sudo apt install python3-distutils
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -44,16 +44,11 @@ pgrep -af hamster
 ##### Debian-based
 
 ###### Ubuntu (tested in 19.04 and 18.04)
-Run-time:
+
 ```bash
-sudo apt install gettext intltool gconf2 gir1.2-gconf-2.0 python3-gi-cairo
+sudo apt install gettext intltool gconf2 gir1.2-gconf-2.0 python3-gi-cairo python3-distutils
 sudo apt install gnome-doc-utils yelp
 ```
-Build:
-```bash
-sudo apt install python3-distutils
-```
-
 
 ##### openSUSE
 


### PR DESCRIPTION
The waf build will fail without it and the suggested package in the error message (`install "python-devel"`) is not helping.