### PR TITLE
Add some tooltips for overview buttons

### DIFF
--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -73,7 +73,7 @@ class HeaderBar(gtk.HeaderBar):
         self.system_button = gtk.MenuButton()
         self.system_button.set_image(gtk.Image.new_from_icon_name(
             "open-menu-symbolic", gtk.IconSize.MENU))
-        self.search_button.set_tooltip_markup("Menu")
+        self.system_button.set_tooltip_markup("Menu")
         self.pack_end(self.system_button)
 
         self.search_button = gtk.ToggleButton()

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -91,6 +91,7 @@ class HeaderBar(gtk.HeaderBar):
         self.add_activity_button = gtk.Button()
         self.add_activity_button.set_image(gtk.Image.new_from_icon_name(
             "list-add-symbolic", gtk.IconSize.MENU))
+        self.add_activity_button.set_tooltip_markup(_("Add activity (Ctrl-N)"))
         self.pack_end(self.add_activity_button)
 
 
@@ -451,7 +452,7 @@ class Overview(Controller):
         self.fact_tree = FactTree()
         self.fact_tree.connect("on-activate-row", self.on_row_activated)
         self.fact_tree.connect("on-delete-called", self.on_row_delete_called)
-        self.fact_tree.connect("selection-changed", self.on_selection_changed)
+
         window.add(self.fact_tree)
         main.pack_start(window, True, True, 1)
 
@@ -555,13 +556,6 @@ class Overview(Controller):
 
     def on_add_activity_clicked(self, button):
         self.start_new_fact(clone_selected=True, fallback=True)
-
-    def on_selection_changed(self, tree, fact):
-        if fact:
-            markup = _("Resume/clone activity (Ctrl-+ or Ctrl-R)")
-        else:
-            markup = _("Add new activity (Ctrl-+ or Ctrl-N)")
-        self.header_bar.add_activity_button.set_tooltip_markup(markup)
 
     def on_stop_clicked(self, button):
         self.storage.stop_tracking()

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -558,9 +558,9 @@ class Overview(Controller):
 
     def on_selection_changed(self, tree, fact):
         if fact:
-            markup = _("Resume/clone activity (Ctrl-R)")
+            markup = _("Resume/clone activity (Ctrl-+ or Ctrl-R)")
         else:
-            markup = _("Add new activity (Ctrl-N)")
+            markup = _("Add new activity (Ctrl-+ or Ctrl-N)")
         self.header_bar.add_activity_button.set_tooltip_markup(markup)
 
     def on_stop_clicked(self, button):

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -532,6 +532,8 @@ class Overview(Controller):
         self.facts = self.storage.get_facts(start, end, search_terms=search)
         self.fact_tree.set_facts(self.facts)
         self.totals.set_facts(self.facts)
+        self.header_bar.stop_button.set_sensitive(
+            self.facts and not self.facts[-1].end_time)
 
     def on_range_selected(self, button, range_type, start, end):
         self.find_facts()

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -91,7 +91,6 @@ class HeaderBar(gtk.HeaderBar):
         self.add_activity_button = gtk.Button()
         self.add_activity_button.set_image(gtk.Image.new_from_icon_name(
             "list-add-symbolic", gtk.IconSize.MENU))
-        self.add_activity_button.set_tooltip_markup(_("Add activity (Ctrl-N)"))
         self.pack_end(self.add_activity_button)
 
 
@@ -452,7 +451,7 @@ class Overview(Controller):
         self.fact_tree = FactTree()
         self.fact_tree.connect("on-activate-row", self.on_row_activated)
         self.fact_tree.connect("on-delete-called", self.on_row_delete_called)
-
+        self.fact_tree.connect("selection-changed", self.on_selection_changed)
         window.add(self.fact_tree)
         main.pack_start(window, True, True, 1)
 
@@ -556,6 +555,13 @@ class Overview(Controller):
 
     def on_add_activity_clicked(self, button):
         self.start_new_fact(clone_selected=True, fallback=True)
+
+    def on_selection_changed(self, tree, fact):
+        if fact:
+            markup = _("Resume/clone activity (Ctrl-R)")
+        else:
+            markup = _("Add new activity (Ctrl-N)")
+        self.header_bar.add_activity_button.set_tooltip_markup(markup)
 
     def on_stop_clicked(self, button):
         self.storage.stop_tracking()

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -73,25 +73,25 @@ class HeaderBar(gtk.HeaderBar):
         self.system_button = gtk.MenuButton()
         self.system_button.set_image(gtk.Image.new_from_icon_name(
             "open-menu-symbolic", gtk.IconSize.MENU))
-        self.system_button.set_tooltip_markup("Menu")
+        self.system_button.set_tooltip_markup(_("Menu"))
         self.pack_end(self.system_button)
 
         self.search_button = gtk.ToggleButton()
         self.search_button.set_image(gtk.Image.new_from_icon_name(
             "edit-find-symbolic", gtk.IconSize.MENU))
-        self.search_button.set_tooltip_markup("Filter activities")
+        self.search_button.set_tooltip_markup(_("Filter activities"))
         self.pack_end(self.search_button)
 
         self.stop_button = gtk.Button()
         self.stop_button.set_image(gtk.Image.new_from_icon_name(
             "process-stop-symbolic", gtk.IconSize.MENU))
-        self.stop_button.set_tooltip_markup("Stop tracking (Ctrl-SPACE)")
+        self.stop_button.set_tooltip_markup(_("Stop tracking (Ctrl-SPACE)"))
         self.pack_end(self.stop_button)
 
         self.add_activity_button = gtk.Button()
         self.add_activity_button.set_image(gtk.Image.new_from_icon_name(
             "list-add-symbolic", gtk.IconSize.MENU))
-        self.add_activity_button.set_tooltip_markup("Add activity (Ctrl-N)")
+        self.add_activity_button.set_tooltip_markup(_("Add activity (Ctrl-N)"))
         self.pack_end(self.add_activity_button)
 
 

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -91,7 +91,7 @@ class HeaderBar(gtk.HeaderBar):
         self.add_activity_button = gtk.Button()
         self.add_activity_button.set_image(gtk.Image.new_from_icon_name(
             "list-add-symbolic", gtk.IconSize.MENU))
-        self.add_activity_button.set_tooltip_markup(_("Add activity (Ctrl-N)"))
+        self.add_activity_button.set_tooltip_markup(_("Add activity (Ctrl-+)"))
         self.pack_end(self.add_activity_button)
 
 

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -73,21 +73,25 @@ class HeaderBar(gtk.HeaderBar):
         self.system_button = gtk.MenuButton()
         self.system_button.set_image(gtk.Image.new_from_icon_name(
             "open-menu-symbolic", gtk.IconSize.MENU))
+        self.search_button.set_tooltip_markup("Menu")
         self.pack_end(self.system_button)
 
         self.search_button = gtk.ToggleButton()
         self.search_button.set_image(gtk.Image.new_from_icon_name(
             "edit-find-symbolic", gtk.IconSize.MENU))
+        self.search_button.set_tooltip_markup("Filter activities")
         self.pack_end(self.search_button)
 
         self.stop_button = gtk.Button()
         self.stop_button.set_image(gtk.Image.new_from_icon_name(
             "process-stop-symbolic", gtk.IconSize.MENU))
+        self.stop_button.set_tooltip_markup("Stop tracking (Ctrl-SPACE)")
         self.pack_end(self.stop_button)
 
         self.add_activity_button = gtk.Button()
         self.add_activity_button.set_image(gtk.Image.new_from_icon_name(
             "list-add-symbolic", gtk.IconSize.MENU))
+        self.add_activity_button.set_tooltip_markup("Add activity (Ctrl-N)")
         self.pack_end(self.add_activity_button)
 
 

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -264,7 +264,6 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         # enter or double-click, passes in current day and fact
         'on-activate-row': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT, gobject.TYPE_PYOBJECT)),
         'on-delete-called': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT,)),
-        'selection-changed': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT,)),
     }
 
 
@@ -395,13 +394,11 @@ class FactTree(graphics.Scene, gtk.Scrollable):
             self.y = fact.y - self.height + 25
 
         self.on_scroll()
-        self.emit("selection-changed", self.current_fact)
 
     def unset_current_fact(self):
         """Deselect fact."""
         self.current_fact = None
         self.on_scroll()
-        self.emit("selection-changed", self.current_fact)
 
     def get_visible_range(self):
         start, end = (bisect.bisect(self.row_positions, self.y) - 1,

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -264,6 +264,7 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         # enter or double-click, passes in current day and fact
         'on-activate-row': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT, gobject.TYPE_PYOBJECT)),
         'on-delete-called': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT,)),
+        'selection-changed': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT,)),
     }
 
 
@@ -394,11 +395,13 @@ class FactTree(graphics.Scene, gtk.Scrollable):
             self.y = fact.y - self.height + 25
 
         self.on_scroll()
+        self.emit("selection-changed", self.current_fact)
 
     def unset_current_fact(self):
         """Deselect fact."""
         self.current_fact = None
         self.on_scroll()
+        self.emit("selection-changed", self.current_fact)
 
     def get_visible_range(self):
         start, end = (bisect.bisect(self.row_positions, self.y) - 1,


### PR DESCRIPTION
Add tooltips for the buttons on the overview header bar to improve discoverability for first time users (cf. #447)