### PR TITLE
scroll till the end of last fact

### DIFF
--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -395,8 +395,8 @@ class FactTree(graphics.Scene, gtk.Scrollable):
 
         if fact.y < self.y:
             self.y = fact.y
-        if (fact.y + 25) > (self.y + self.height):
-            self.y = fact.y - self.height + 25
+        if (fact.y + fact.height) > (self.y + self.height):
+            self.y = fact.y + fact.height - self.height
 
         self.on_scroll()
 


### PR DESCRIPTION
In the overview, upon selection,
now display completely the last fact,
even if tags or description are present.