### PR TITLE
Rename input dialog to "Add activity"

### DIFF
--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -71,6 +71,7 @@ class CustomFactController(gobject.GObject):
             original_fact = fact
             self.window.set_title(_("Update activity"))
         else:
+            self.window.set_title(_("Add activity"))
             self.date = hamster_today()
             self.get_widget("delete_button").set_sensitive(False)
             if base_fact:


### PR DESCRIPTION
As discussed elsewhere, the "Add Earlier Activity" dialog should be renamed to "Add activity" because it can be used to enter earlier, current or even future activities. Use lowercase "activity" to be consitent with "Update activity".