### PR TITLE
Update Debian based dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ pgrep -af hamster
 ###### Ubuntu (tested in 19.04 and 18.04)
 
 ```bash
-sudo apt install gettext intltool gconf2 gir1.2-gconf-2.0 python3-gi-cairo python3-distutils
-sudo apt install gnome-doc-utils yelp
+sudo apt install gconf2 gir1.2-gconf-2.0 python3-gi-cairo python3-distutils python3-dbus python3-xdg
+sudo apt install gettext intltool gnome-doc-utils yelp
 ```
 
 ##### openSUSE

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ pgrep -af hamster
 ###### Ubuntu (tested in 19.04 and 18.04)
 
 ```bash
-sudo apt install gconf2 gir1.2-gconf-2.0 python3-gi-cairo python3-distutils python3-dbus python3-xdg
-sudo apt install gettext intltool gnome-doc-utils yelp
+sudo apt install gettext intltool gconf2 gir1.2-gconf-2.0 python3-gi-cairo python3-distutils python3-dbus python3-xdg
+# and for documentation
+sudo apt install gnome-doc-utils yelp
 ```
 
 ##### openSUSE


### PR DESCRIPTION
Add python3-xdg and python3-dbus.

Refs #459 regarding Debian testing. I also needed python3-dbus on Ubuntu 18.04.