### PR TITLE
Separate edit fields

### DIFF
--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -342,7 +342,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkEntry">
+                  <object class="GtkEntry" id="category">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                   </object>

--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -366,6 +366,38 @@
           </packing>
         </child>
         <child>
+          <object class="GtkBox" id="tags box">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">tags</property>
+                <attributes>
+                  <attribute name="style" value="italic"/>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">5</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkBox" id="buttons box">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -431,7 +463,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
+            <property name="position">6</property>
           </packing>
         </child>
       </object>

--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -181,10 +181,13 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkEntry">
+                  <object class="GtkBox" id="start time box">
                     <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <placeholder/>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -236,10 +239,13 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkEntry">
+                  <object class="GtkBox" id="end time box">
                     <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <placeholder/>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -205,6 +205,7 @@
                   <object class="GtkExpander" id="start date expander">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="label_fill">True</property>
                     <property name="resize_toplevel">True</property>
                     <child>
                       <object class="GtkCalendar" id="start date">
@@ -277,6 +278,7 @@
                   <object class="GtkExpander" id="end date expander">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="label_fill">True</property>
                     <property name="resize_toplevel">True</property>
                     <child>
                       <object class="GtkCalendar" id="end date">

--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -193,7 +193,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkCalendar">
+                  <object class="GtkCalendar" id="start date">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="year">2019</property>
@@ -248,7 +248,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkCalendar">
+                  <object class="GtkCalendar" id="end date">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="year">2019</property>

--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -302,7 +302,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkEntry">
+                  <object class="GtkEntry" id="activity">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                   </object>

--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -359,7 +359,8 @@
                   <object class="GtkEntry" id="category">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="secondary_icon_stock">gtk-clear</property>
+                    <property name="primary_icon_name">edit-delete</property>
+                    <property name="secondary_icon_name">go-down-symbolic</property>
                     <property name="completion">category completion</property>
                   </object>
                   <packing>

--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -292,51 +292,9 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <child>
-              <object class="GtkBox" id="activity box">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="label" translatable="yes">activity</property>
-                    <attributes>
-                      <attribute name="style" value="italic"/>
-                      <attribute name="weight" value="bold"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="activity">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="secondary_icon_stock">gtk-clear</property>
-                    <property name="completion">activity completion</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="resize">True</property>
-                <property name="shrink">False</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkBox" id="category box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_left">4</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkLabel">
@@ -359,8 +317,49 @@
                   <object class="GtkEntry" id="category">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="primary_icon_name">edit-delete</property>
-                    <property name="secondary_icon_name">go-down-symbolic</property>
+                    <property name="primary_icon_name">edit-clear-all-symbolic</property>
+                    <property name="completion">activity completion</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="resize">True</property>
+                <property name="shrink">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="activity box">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">4</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">activity</property>
+                    <attributes>
+                      <attribute name="style" value="italic"/>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="activity">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="primary_icon_name">edit-clear-all-symbolic</property>
                     <property name="completion">category completion</property>
                   </object>
                   <packing>

--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -2,6 +2,9 @@
 <!-- Generated with glade 3.20.4 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
+  <object class="GtkEntryCompletion" id="category completion">
+    <property name="minimum_key_length">0</property>
+  </object>
   <object class="GtkWindow" id="custom_fact_window">
     <property name="can_focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
@@ -351,6 +354,8 @@
                   <object class="GtkEntry" id="category">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="secondary_icon_stock">gtk-clear</property>
+                    <property name="completion">category completion</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>

--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -202,12 +202,26 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkCalendar" id="start date">
+                  <object class="GtkExpander" id="start date expander">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="year">2019</property>
-                    <property name="month">8</property>
-                    <property name="day">15</property>
+                    <property name="resize_toplevel">True</property>
+                    <child>
+                      <object class="GtkCalendar" id="start date">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="year">2019</property>
+                        <property name="month">8</property>
+                        <property name="day">15</property>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">start date</property>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -260,12 +274,26 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkCalendar" id="end date">
+                  <object class="GtkExpander" id="end date expander">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="year">2019</property>
-                    <property name="month">8</property>
-                    <property name="day">15</property>
+                    <property name="resize_toplevel">True</property>
+                    <child>
+                      <object class="GtkCalendar" id="end date">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="year">2019</property>
+                        <property name="month">8</property>
+                        <property name="day">15</property>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">end date</property>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -2,6 +2,9 @@
 <!-- Generated with glade 3.20.4 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
+  <object class="GtkEntryCompletion" id="activity completion">
+    <property name="minimum_key_length">0</property>
+  </object>
   <object class="GtkEntryCompletion" id="category completion">
     <property name="minimum_key_length">0</property>
   </object>
@@ -314,6 +317,8 @@
                   <object class="GtkEntry" id="activity">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="secondary_icon_stock">gtk-clear</property>
+                    <property name="completion">activity completion</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -51,7 +51,7 @@ class CustomFactController(gobject.GObject):
         self.activity_entry = self.get_widget('activity')
         self.category_entry = self.get_widget('category')
 
-        self.cmdline = widgets.ActivityEntry()
+        self.cmdline = widgets.CmdLineEntry()
         self.get_widget("command line box").add(self.cmdline)
         self.cmdline.connect("focus_in_event", self.on_cmdline_focus_in_event)
         self.cmdline.connect("focus_out_event", self.on_cmdline_focus_out_event)

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -197,6 +197,9 @@ class CustomFactController(gobject.GObject):
                 self.cmdline.select_region(0, time_len - 1)
 
     def update_fields(self):
+        self.start_time.set_time(self.fact.start_time)
+        self.end_time.set_time(self.fact.end_time)
+        self.end_time.set_start_time(self.fact.start_time)
         self.start_date.date = self.fact.start_time
         self.end_date.date = self.fact.end_time
         self.activity_entry.set_text(self.fact.activity)

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -92,7 +92,7 @@ class CustomFactController(gobject.GObject):
                 self.fact = base_fact.copy(start_time=hamster_now(),
                                            end_time=None)
             else:
-                self.fact = Fact()
+                self.fact = Fact(start_time=hamster_now())
 
         original_fact = self.fact
 

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -97,6 +97,7 @@ class CustomFactController(gobject.GObject):
         # not at init time when cmdline might not always be fully parsable.
         self.cmdline.connect("changed", self.on_cmdline_changed)
         self.activity_entry.connect("changed", self.on_activity_changed)
+        self.category_entry.connect("changed", self.on_category_changed)
         self.tags_entry.connect("changed", self.on_tags_changed)
 
         self._gui.connect_signals(self)
@@ -150,6 +151,11 @@ class CustomFactController(gobject.GObject):
     def on_activity_changed(self, widget):
         if not self.master_is_cmdline:
             self.fact.activity = self.activity_entry.get_text()
+            self.update_cmdline()
+
+    def on_category_changed(self, widget):
+        if not self.master_is_cmdline:
+            self.fact.category = self.category_entry.get_text()
             self.update_cmdline()
 
     def on_cmdline_changed(self, widget):

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -185,6 +185,7 @@ class CustomFactController(gobject.GObject):
             self.update_cmdline()
 
     def update_cmdline(self, select=None):
+        """Update the cmdline entry content."""
         stripped_fact = self.fact.copy(description=None)
         label = stripped_fact.serialized(prepend_date=False)
         with self.cmdline.handler_block(self.cmdline.checker):
@@ -194,6 +195,7 @@ class CustomFactController(gobject.GObject):
                 self.cmdline.select_region(0, time_len - 1)
 
     def update_fields(self):
+        """Update gui fields content."""
         self.start_time.set_time(self.fact.start_time)
         self.end_time.set_time(self.fact.end_time)
         self.end_time.set_start_time(self.fact.start_time)

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -48,6 +48,8 @@ class CustomFactController(gobject.GObject):
         # None if creating a new fact, instead of editing one
         self.fact_id = fact_id
 
+        self.activity_entry = self.get_widget('activity')
+
         self.cmdline = widgets.ActivityEntry()
         self.cmdline.connect("changed", self.on_cmdline_changed)
         self.get_widget("command line box").add(self.cmdline)
@@ -142,6 +144,8 @@ class CustomFactController(gobject.GObject):
 
     def on_cmdline_changed(self, combo):
         self.validate_fields()
+        self.fact = Fact.parse(self.cmdline.get_text())
+        self.activity_entry.set_text(self.fact.activity)
 
     def update_status(self, status, markup):
         """Set save button sensitivity and tooltip."""

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -189,11 +189,17 @@ class CustomFactController(gobject.GObject):
             self.update_cmdline()
 
     def on_end_date_changed(self, widget):
-        if self.fact.end_time and not self.master_is_cmdline:
-            time = self.fact.end_time.time()
-            self.fact.end_time = dt.datetime.combine(self.end_date.date, time)
-            self.validate_fields()
-            self.update_cmdline()
+        if not self.master_is_cmdline:
+            if self.fact.end_time:
+                time = self.fact.end_time.time()
+                self.fact.end_time = dt.datetime.combine(self.end_date.date, time)
+                self.validate_fields()
+                self.update_cmdline()
+            elif self.end_date.date:
+                # No end time means on-going, hence date would be meaningless.
+                # And a default end date may be provided when end time is set,
+                # so there should never be a date without time.
+                self.end_date.date = None
 
     def on_end_time_changed(self, widget):
         if not self.master_is_cmdline:

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -56,8 +56,6 @@ class CustomFactController(gobject.GObject):
         self.cmdline.connect("focus_in_event", self.on_cmdline_focus_in_event)
         self.cmdline.connect("focus_out_event", self.on_cmdline_focus_out_event)
 
-        self.day_start = conf.day_start
-
         self.dayline = widgets.DayLine()
         self._gui.get_object("day_preview").add(self.dayline)
 

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -79,7 +79,9 @@ class CustomFactController(gobject.GObject):
 
         self.save_button = self.get_widget("save_button")
 
+        # this will set self.master_is_cmdline
         self.cmdline.grab_focus()
+
         if fact_id:
             # editing
             self.fact = runtime.storage.get_fact(fact_id)
@@ -162,11 +164,12 @@ class CustomFactController(gobject.GObject):
 
     def on_cmdline_changed(self, widget):
         if self.master_is_cmdline:
-            previous_cmdline_fact = self.cmdline_fact
             fact = Fact.parse(self.cmdline.get_text(), date=self.date)
+            previous_cmdline_fact = self.cmdline_fact
+            # copy the entered fact before any modification
+            self.cmdline_fact = fact.copy()
             if fact.start_time is None:
                 fact.start_time = hamster_now()
-            self.cmdline_fact = fact.copy()
             if fact.description == previous_cmdline_fact.description:
                 # no change to description here, keep the main one
                 fact.description = self.fact.description

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -63,6 +63,9 @@ class CustomFactController(gobject.GObject):
         self.description_buffer = self.description_box.get_buffer()
         self.description_buffer.connect("changed", self.on_description_changed)
 
+        self.end_date = widgets.Calendar(widget=self.get_widget("end date"))
+        self.start_date = widgets.Calendar(widget=self.get_widget("start date"))
+
         self.tags_entry = widgets.TagsEntry()
         self.get_widget("tags box").add(self.tags_entry)
 
@@ -161,8 +164,6 @@ class CustomFactController(gobject.GObject):
             self.validate_fields()
             previous_description = self.fact.description
             fact = Fact.parse(self.cmdline.get_text())
-            self.activity_entry.set_text(fact.activity)
-            self.category_entry.set_text(fact.category)
             if not fact.description:
                 fact.description = previous_description
             self.fact = fact
@@ -189,6 +190,8 @@ class CustomFactController(gobject.GObject):
                 self.cmdline.select_region(0, time_len - 1)
 
     def update_fields(self):
+        self.start_date.date = self.fact.start_time
+        self.end_date.date = self.fact.end_time
         self.activity_entry.set_text(self.fact.activity)
         self.category_entry.set_text(self.fact.category)
         self.description_buffer.set_text(self.fact.description)

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -48,8 +48,9 @@ class CustomFactController(gobject.GObject):
         # None if creating a new fact, instead of editing one
         self.fact_id = fact_id
 
-        self.activity_entry = self.get_widget('activity')
         self.category_entry = widgets.CategoryEntry(widget=self.get_widget('category'))
+        self.activity_entry = widgets.ActivityEntry(widget=self.get_widget('activity'),
+                                                    category_widget=self.category_entry)
 
         self.cmdline = widgets.CmdLineEntry()
         self.get_widget("command line box").add(self.cmdline)

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -63,7 +63,6 @@ class CustomFactController(gobject.GObject):
 
         self.description_box = self.get_widget('description')
         self.description_buffer = self.description_box.get_buffer()
-        self.description_buffer.connect("changed", self.on_description_changed)
 
         self.end_date = widgets.Calendar(widget=self.get_widget("end date"))
 
@@ -108,6 +107,7 @@ class CustomFactController(gobject.GObject):
         # This signal should be emitted only after a manual modification,
         # not at init time when cmdline might not always be fully parsable.
         self.cmdline.connect("changed", self.on_cmdline_changed)
+        self.description_buffer.connect("changed", self.on_description_changed)
         self.start_time.connect("changed", self.on_start_time_changed)
         self.start_date.connect("day-selected", self.on_start_date_changed)
         self.end_time.connect("changed", self.on_end_time_changed)

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -64,7 +64,14 @@ class CustomFactController(gobject.GObject):
         self.description_buffer.connect("changed", self.on_description_changed)
 
         self.end_date = widgets.Calendar(widget=self.get_widget("end date"))
+
+        self.end_time = widgets.TimeInput()
+        self.get_widget("end time box").add(self.end_time)
+
         self.start_date = widgets.Calendar(widget=self.get_widget("start date"))
+
+        self.start_time = widgets.TimeInput()
+        self.get_widget("start time box").add(self.start_time)
 
         self.tags_entry = widgets.TagsEntry()
         self.get_widget("tags box").add(self.tags_entry)

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -173,6 +173,8 @@ class CustomFactController(gobject.GObject):
             fact = Fact.parse(self.cmdline.get_text(), date=self.date)
             if not fact.description:
                 fact.description = previous_description
+            if fact.start_time is None:
+                fact.start_time = hamster_now()
             self.fact = fact
             self.update_fields()
 

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -64,12 +64,14 @@ class CustomFactController(gobject.GObject):
         self.description_box = self.get_widget('description')
         self.description_buffer = self.description_box.get_buffer()
 
-        self.end_date = widgets.Calendar(widget=self.get_widget("end date"))
+        self.end_date = widgets.Calendar(widget=self.get_widget("end date"),
+                                         expander=self.get_widget("end date expander"))
 
         self.end_time = widgets.TimeInput()
         self.get_widget("end time box").add(self.end_time)
 
-        self.start_date = widgets.Calendar(widget=self.get_widget("start date"))
+        self.start_date = widgets.Calendar(widget=self.get_widget("start date"),
+                                           expander=self.get_widget("start date expander"))
 
         self.start_time = widgets.TimeInput()
         self.get_widget("start time box").add(self.start_time)
@@ -110,8 +112,12 @@ class CustomFactController(gobject.GObject):
         self.description_buffer.connect("changed", self.on_description_changed)
         self.start_time.connect("changed", self.on_start_time_changed)
         self.start_date.connect("day-selected", self.on_start_date_changed)
+        self.start_date.expander.connect("activate",
+                                         self.on_start_date_expander_activated)
         self.end_time.connect("changed", self.on_end_time_changed)
         self.end_date.connect("day-selected", self.on_end_date_changed)
+        self.end_date.expander.connect("activate",
+                                         self.on_end_date_expander_activated)
         self.activity_entry.connect("changed", self.on_activity_changed)
         self.category_entry.connect("changed", self.on_category_changed)
         self.tags_entry.connect("changed", self.on_tags_changed)
@@ -202,6 +208,11 @@ class CustomFactController(gobject.GObject):
                 # so there should never be a date without time.
                 self.end_date.date = None
 
+    def on_end_date_expander_activated(self, widget):
+        # state has not changed yet, toggle also start_date calendar visibility
+        previous_state = self.end_date.expander.get_expanded()
+        self.start_date.expander.set_expanded(not previous_state)
+
     def on_end_time_changed(self, widget):
         if not self.master_is_cmdline:
             # self.end_time.start_time() was given a datetime,
@@ -226,6 +237,11 @@ class CustomFactController(gobject.GObject):
             self.date = self.fact.date or hamster_today()
             self.validate_fields()
             self.update_cmdline()
+
+    def on_start_date_expander_activated(self, widget):
+        # state has not changed yet, toggle also end_date calendar visibility
+        previous_state = self.start_date.expander.get_expanded()
+        self.end_date.expander.set_expanded(not previous_state)
 
     def on_start_time_changed(self, widget):
         if not self.master_is_cmdline:

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -49,6 +49,7 @@ class CustomFactController(gobject.GObject):
         self.fact_id = fact_id
 
         self.activity_entry = self.get_widget('activity')
+        self.category_entry = self.get_widget('category')
 
         self.cmdline = widgets.ActivityEntry()
         self.cmdline.connect("changed", self.on_cmdline_changed)
@@ -146,6 +147,7 @@ class CustomFactController(gobject.GObject):
         self.validate_fields()
         self.fact = Fact.parse(self.cmdline.get_text())
         self.activity_entry.set_text(self.fact.activity)
+        self.category_entry.set_text(self.fact.category)
 
     def update_status(self, status, markup):
         """Set save button sensitivity and tooltip."""

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -104,6 +104,7 @@ class CustomFactController(gobject.GObject):
         # This signal should be emitted only after a manual modification,
         # not at init time when cmdline might not always be fully parsable.
         self.cmdline.connect("changed", self.on_cmdline_changed)
+        self.start_date.connect("day-selected", self.on_start_date_changed)
         self.activity_entry.connect("changed", self.on_activity_changed)
         self.category_entry.connect("changed", self.on_category_changed)
         self.tags_entry.connect("changed", self.on_tags_changed)
@@ -178,6 +179,20 @@ class CustomFactController(gobject.GObject):
 
     def on_cmdline_focus_out_event(self, widget, event):
         self.master_is_cmdline = False
+
+    def on_start_date_changed(self, widget):
+        if not self.master_is_cmdline:
+            previous_date = self.fact.start_time.date()
+            new_date = self.start_date.date
+            delta = new_date - previous_date
+            self.fact.start_time += delta
+            if self.fact.end_time:
+                # preserve fact duration
+                self.fact.end_time += delta
+                self.end_date.date = self.fact.end_time
+            self.date = self.fact.date
+            self.validate_fields()
+            self.update_cmdline()
 
     def on_tags_changed(self, widget):
         if not self.master_is_cmdline:

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -105,6 +105,7 @@ class CustomFactController(gobject.GObject):
         # not at init time when cmdline might not always be fully parsable.
         self.cmdline.connect("changed", self.on_cmdline_changed)
         self.start_date.connect("day-selected", self.on_start_date_changed)
+        self.end_date.connect("day-selected", self.on_end_date_changed)
         self.activity_entry.connect("changed", self.on_activity_changed)
         self.category_entry.connect("changed", self.on_category_changed)
         self.tags_entry.connect("changed", self.on_tags_changed)
@@ -179,6 +180,13 @@ class CustomFactController(gobject.GObject):
 
     def on_cmdline_focus_out_event(self, widget, event):
         self.master_is_cmdline = False
+
+    def on_end_date_changed(self, widget):
+        if self.fact.end_time and not self.master_is_cmdline:
+            time = self.fact.end_time.time()
+            self.fact.end_time = dt.datetime.combine(self.end_date.date, time)
+            self.validate_fields()
+            self.update_cmdline()
 
     def on_start_date_changed(self, widget):
         if not self.master_is_cmdline:

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -104,6 +104,7 @@ class CustomFactController(gobject.GObject):
         # This signal should be emitted only after a manual modification,
         # not at init time when cmdline might not always be fully parsable.
         self.cmdline.connect("changed", self.on_cmdline_changed)
+        self.start_time.connect("changed", self.on_start_time_changed)
         self.start_date.connect("day-selected", self.on_start_date_changed)
         self.end_date.connect("day-selected", self.on_end_date_changed)
         self.activity_entry.connect("changed", self.on_activity_changed)
@@ -199,6 +200,18 @@ class CustomFactController(gobject.GObject):
                 self.fact.end_time += delta
                 self.end_date.date = self.fact.end_time
             self.date = self.fact.date
+            self.validate_fields()
+            self.update_cmdline()
+
+    def on_start_time_changed(self, widget):
+        if not self.master_is_cmdline:
+            previous_time = self.fact.start_time.time()
+            new_time = self.start_time.time
+            if new_time:
+                date = self.fact.start_time.date()
+                self.fact.start_time = dt.datetime.combine(date, new_time)
+            else:
+                self.fact.start_time = None
             self.validate_fields()
             self.update_cmdline()
 

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -49,7 +49,7 @@ class CustomFactController(gobject.GObject):
         self.fact_id = fact_id
 
         self.activity_entry = self.get_widget('activity')
-        self.category_entry = self.get_widget('category')
+        self.category_entry = widgets.CategoryEntry(widget=self.get_widget('category'))
 
         self.cmdline = widgets.CmdLineEntry()
         self.get_widget("command line box").add(self.cmdline)

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -161,11 +161,13 @@ class CustomFactController(gobject.GObject):
     def on_activity_changed(self, widget):
         if not self.master_is_cmdline:
             self.fact.activity = self.activity_entry.get_text()
+            self.validate_fields()
             self.update_cmdline()
 
     def on_category_changed(self, widget):
         if not self.master_is_cmdline:
             self.fact.category = self.category_entry.get_text()
+            self.validate_fields()
             self.update_cmdline()
 
     def on_cmdline_changed(self, widget):

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -229,8 +229,8 @@ class CustomFactController(gobject.GObject):
         with self.cmdline.handler_block(self.cmdline.checker):
             self.cmdline.set_text(label)
             if select:
-                time_len = len(label) - len(stripped_fact.serialized_name())
-                self.cmdline.select_region(0, time_len - 1)
+                time_str = stripped_fact.serialized_time(prepend_date=False)
+                self.cmdline.select_region(0, len(time_str))
 
     def update_fields(self):
         """Update gui fields content."""

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -148,13 +148,6 @@ class CustomFactController(gobject.GObject):
         description = buf.get_text(buf.get_start_iter(), buf.get_end_iter(), 0)
         return description.strip()
 
-    def on_save_button_clicked(self, button):
-        if self.fact_id:
-            runtime.storage.update_fact(self.fact_id, self.fact)
-        else:
-            runtime.storage.add_fact(self.fact)
-        self.close_window()
-
     def on_activity_changed(self, widget):
         if not self.master_is_cmdline:
             self.fact.activity = self.activity_entry.get_text()
@@ -338,6 +331,13 @@ class CustomFactController(gobject.GObject):
         self.close_window()
 
     def on_close(self, widget, event):
+        self.close_window()
+
+    def on_save_button_clicked(self, button):
+        if self.fact_id:
+            runtime.storage.update_fact(self.fact_id, self.fact)
+        else:
+            runtime.storage.add_fact(self.fact)
         self.close_window()
 
     def on_window_key_pressed(self, tree, event_key):

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -355,7 +355,8 @@ class CustomFactController(gobject.GObject):
                 return False
             if self.description_box.has_focus():
                 return False
-            self.on_save_button_clicked(None)
+            if self.validate_fields():
+                self.on_save_button_clicked(None)
 
     def close_window(self):
         if not self.parent:

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -52,7 +52,6 @@ class CustomFactController(gobject.GObject):
         self.category_entry = self.get_widget('category')
 
         self.cmdline = widgets.ActivityEntry()
-        self.cmdline.connect("changed", self.on_cmdline_changed)
         self.get_widget("command line box").add(self.cmdline)
 
         self.day_start = conf.day_start
@@ -94,6 +93,10 @@ class CustomFactController(gobject.GObject):
             self.description_buffer.set_text(original_fact.description)
 
         self.cmdline.original_fact = original_fact
+
+        # This signal should be emitted only after a manual modification,
+        # not at init time when cmdline might not always be fully parsable.
+        self.cmdline.connect("changed", self.on_cmdline_changed)
 
         self._gui.connect_signals(self)
         self.validate_fields()

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -227,7 +227,8 @@ class CustomFactController(gobject.GObject):
 
     def on_start_time_changed(self, widget):
         if not self.master_is_cmdline:
-            previous_time = self.fact.start_time.time()
+            # note: resist the temptation to preserve duration here;
+            # for instance, end time might be at the beginning of next fact.
             new_time = self.start_time.time
             if new_time:
                 date = self.fact.start_time.date()

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -351,7 +351,10 @@ class CustomFactController(gobject.GObject):
         self.close_window()
 
     def on_window_key_pressed(self, tree, event_key):
-        popups = self.cmdline.popup.get_property("visible");
+        popups = (self.cmdline.popup.get_property("visible")
+                  or self.start_time.popup.get_property("visible")
+                  or self.end_time.popup.get_property("visible")
+                  or self.tags_entry.popup.get_property("visible"))
 
         if (event_key.keyval == gdk.KEY_Escape or \
            (event_key.keyval == gdk.KEY_w and event_key.state & gdk.ModifierType.CONTROL_MASK)):

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -65,6 +65,9 @@ class CustomFactController(gobject.GObject):
         self.description_buffer = self.description_box.get_buffer()
         self.description_buffer.connect("changed", self.on_description_changed)
 
+        self.tags_entry = widgets.TagsEntry()
+        self.get_widget("tags box").add(self.tags_entry)
+
         self.save_button = self.get_widget("save_button")
 
         self.cmdline.grab_focus()
@@ -94,6 +97,7 @@ class CustomFactController(gobject.GObject):
         # not at init time when cmdline might not always be fully parsable.
         self.cmdline.connect("changed", self.on_cmdline_changed)
         self.activity_entry.connect("changed", self.on_activity_changed)
+        self.tags_entry.connect("changed", self.on_tags_changed)
 
         self._gui.connect_signals(self)
         self.validate_fields()
@@ -166,6 +170,11 @@ class CustomFactController(gobject.GObject):
     def on_cmdline_focus_out_event(self, widget, event):
         self.master_is_cmdline = False
 
+    def on_tags_changed(self, widget):
+        if not self.master_is_cmdline:
+            self.fact.tags = self.tags_entry.get_tags()
+            self.update_cmdline()
+
     def update_cmdline(self, select=None):
         stripped_fact = self.fact.copy(description=None)
         label = stripped_fact.serialized(prepend_date=False)
@@ -179,6 +188,7 @@ class CustomFactController(gobject.GObject):
         self.activity_entry.set_text(self.fact.activity)
         self.category_entry.set_text(self.fact.category)
         self.description_buffer.set_text(self.fact.description)
+        self.tags_entry.set_tags(self.fact.tags)
 
     def update_status(self, status, markup):
         """Set save button sensitivity and tooltip."""

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -219,8 +219,8 @@ class CustomFactController(gobject.GObject):
 
     def update_fields(self):
         """Update gui fields content."""
-        self.start_time.set_time(self.fact.start_time)
-        self.end_time.set_time(self.fact.end_time)
+        self.start_time.time = self.fact.start_time
+        self.end_time.time = self.fact.end_time
         self.end_time.set_start_time(self.fact.start_time)
         self.start_date.date = self.fact.start_time
         self.end_date.date = self.fact.end_time

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -106,6 +106,7 @@ class CustomFactController(gobject.GObject):
         self.cmdline.connect("changed", self.on_cmdline_changed)
         self.start_time.connect("changed", self.on_start_time_changed)
         self.start_date.connect("day-selected", self.on_start_date_changed)
+        self.end_time.connect("changed", self.on_end_time_changed)
         self.end_date.connect("day-selected", self.on_end_date_changed)
         self.activity_entry.connect("changed", self.on_activity_changed)
         self.category_entry.connect("changed", self.on_category_changed)
@@ -188,6 +189,16 @@ class CustomFactController(gobject.GObject):
         if self.fact.end_time and not self.master_is_cmdline:
             time = self.fact.end_time.time()
             self.fact.end_time = dt.datetime.combine(self.end_date.date, time)
+            self.validate_fields()
+            self.update_cmdline()
+
+    def on_end_time_changed(self, widget):
+        if not self.master_is_cmdline:
+            # self.end_time.start_time() was given a datetime,
+            # so self.end_time.time is a datetime too.
+            end = self.end_time.time
+            self.fact.end_time = end
+            self.end_date.date = end.date() if end else None
             self.validate_fields()
             self.update_cmdline()
 

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -149,11 +149,10 @@ class CustomFactController(gobject.GObject):
         return description.strip()
 
     def on_save_button_clicked(self, button):
-        fact = self.validate_fields()
         if self.fact_id:
-            runtime.storage.update_fact(self.fact_id, fact)
+            runtime.storage.update_fact(self.fact_id, self.fact)
         else:
-            runtime.storage.add_fact(fact)
+            runtime.storage.add_fact(self.fact)
         self.close_window()
 
     def on_activity_changed(self, widget):

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -212,7 +212,9 @@ class Fact(object):
         """Return a string fully representing the fact."""
         name = self.serialized_name()
         datetime = self.serialized_time(prepend_date)
-        return "%s %s" % (datetime, name)
+        # no need for space if name or datetime is missing
+        space = " " if name and datetime else ""
+        return "{}{}{}".format(datetime, space, name)
 
     def _set(self, **kwds):
         """Modify attributes.

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -61,7 +61,12 @@ def datetime_to_hamsterday(civil_date_time):
 
 def hamster_now():
     # current datetime truncated to the minute
-    return dt.datetime.now().replace(second=0, microsecond=0)
+    return hamster_round(dt.datetime.now())
+
+
+def hamster_round(time):
+    """Round time or datetime."""
+    return time.replace(second=0, microsecond=0)
 
 
 def hamster_today():

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -46,6 +46,9 @@ def datetime_to_hamsterday(civil_date_time):
     The hamster day start is taken into account.
     """
 
+    if civil_date_time is None:
+        return None
+
     # work around cyclic imports
     from hamster.lib.configuration import conf
 

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -66,7 +66,10 @@ def hamster_now():
 
 def hamster_round(time):
     """Round time or datetime."""
-    return time.replace(second=0, microsecond=0)
+    if time is None:
+        return None
+    else:
+        return time.replace(second=0, microsecond=0)
 
 
 def hamster_today():

--- a/src/hamster/preferences.py
+++ b/src/hamster/preferences.py
@@ -205,7 +205,7 @@ class PreferencesEditor(Controller):
         self.get_widget("notify_on_idle").set_active(conf.get("notify_on_idle"))
         self.get_widget("notify_on_idle").set_sensitive(conf.get("notify_interval") <=120)
 
-        self.day_start.set_time(conf.day_start)
+        self.day_start.time = conf.day_start
 
         self.tags = [tag["name"] for tag in runtime.storage.get_tags(only_autocomplete=True)]
         self.get_widget("autocomplete_tags").set_text(", ".join(self.tags))
@@ -587,7 +587,7 @@ class PreferencesEditor(Controller):
         self.get_widget("notify_on_idle").set_sensitive(value <= 120)
 
     def on_day_start_changed(self, widget):
-        day_start = self.day_start.get_time()
+        day_start = self.day_start.time
         if day_start is None:
             return
 

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -51,6 +51,8 @@ from hamster.lib.configuration import conf
 from hamster.lib.stuff import hamster_today, hamster_now
 
 
+UNSORTED_ID = -1
+
 
 class Storage(storage.Storage):
     con = None # Connection will be created on demand
@@ -344,6 +346,8 @@ class Storage(storage.Storage):
 
     def __get_category_id(self, name):
         """returns category by it's name"""
+        if not name:
+            return UNSORTED_ID
 
         query = """
                    SELECT id from categories

--- a/src/hamster/widgets/__init__.py
+++ b/src/hamster/widgets/__init__.py
@@ -23,7 +23,7 @@ from gi.repository import Gdk as gdk
 from gi.repository import Pango as pango
 
 # import our children
-from hamster.widgets.activityentry import CmdLineEntry
+from hamster.widgets.activityentry import CategoryEntry, CmdLineEntry
 from hamster.widgets.timeinput import TimeInput
 from hamster.widgets.dayline import DayLine
 from hamster.widgets.tags import Tag, TagBox, TagsEntry

--- a/src/hamster/widgets/__init__.py
+++ b/src/hamster/widgets/__init__.py
@@ -23,7 +23,11 @@ from gi.repository import Gdk as gdk
 from gi.repository import Pango as pango
 
 # import our children
-from hamster.widgets.activityentry import CategoryEntry, CmdLineEntry
+from hamster.widgets.activityentry import (
+    ActivityEntry,
+    CategoryEntry,
+    CmdLineEntry,
+    )
 from hamster.widgets.timeinput import TimeInput
 from hamster.widgets.dayline import DayLine
 from hamster.widgets.tags import Tag, TagBox, TagsEntry

--- a/src/hamster/widgets/__init__.py
+++ b/src/hamster/widgets/__init__.py
@@ -29,7 +29,7 @@ from hamster.widgets.dayline import DayLine
 from hamster.widgets.tags import Tag, TagBox, TagsEntry
 from hamster.widgets.reportchooserdialog import ReportChooserDialog
 from hamster.widgets.facttree import FactTree
-from hamster.widgets.dates import RangePick
+from hamster.widgets.dates import Calendar, RangePick
 
 
 # handy wrappers

--- a/src/hamster/widgets/__init__.py
+++ b/src/hamster/widgets/__init__.py
@@ -23,7 +23,7 @@ from gi.repository import Gdk as gdk
 from gi.repository import Pango as pango
 
 # import our children
-from hamster.widgets.activityentry import ActivityEntry
+from hamster.widgets.activityentry import CmdLineEntry
 from hamster.widgets.timeinput import TimeInput
 from hamster.widgets.dayline import DayLine
 from hamster.widgets.tags import Tag, TagBox, TagsEntry

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -485,13 +485,14 @@ class ActivityEntry():
             self.completion = gtk.EntryCompletion()
             self.widget.set_completion(self.completion)
 
-        # activity, category, text to display
-        self.activity_column = 0
-        self.category_column = 1
-        self.text_column = 2
+        # text to display/filter on, activity, category
+        self.text_column = 0
+        self.activity_column = 1
+        self.category_column = 2
+
         self.model = gtk.ListStore(str, str, str)
         self.completion.set_model(self.model)
-        self.completion.set_text_column(2)
+        self.completion.set_text_column(self.text_column)
         self.completion.set_match_func(self.match_func, None)
 
         self.connect("icon-release", self.on_icon_release)
@@ -539,7 +540,7 @@ class ActivityEntry():
             for activity in runtime.storage.get_category_activities(category_id):
                 activity_name = activity["name"]
                 text = "{}@{}".format(activity_name, category_name)
-                self.model.append([activity_name, category_name, text])
+                self.model.append([text, activity_name, category_name])
 
     def __getattr__(self, name):
         return getattr(self.widget, name)

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -586,7 +586,9 @@ class CategoryEntry():
     def on_icon_release(self, entry, icon_pos, event):
         self.widget.grab_focus()
         self.widget.set_text("")
-        self.emit("changed")
+        # do not emit changed on the primary (clear) button
+        if icon_pos == gtk.EntryIconPosition.SECONDARY:
+            self.emit("changed")
 
     def populate_completions(self):
         self.model.clear()

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -480,6 +480,8 @@ class ActivityEntry():
 
         self.category_widget = category_widget
 
+        # internal list of actions added to the suggestions
+        self._action_list = []
         self.completion = self.widget.get_completion()
         if not self.completion:
             self.completion = gtk.EntryCompletion()
@@ -490,14 +492,48 @@ class ActivityEntry():
         self.activity_column = 1
         self.category_column = 2
 
+        # whether the category choice limit the activity suggestions
+        self.filter_on_category = True if self.category_widget else False
         self.model = gtk.ListStore(str, str, str)
         self.completion.set_model(self.model)
         self.completion.set_text_column(self.text_column)
         self.completion.set_match_func(self.match_func, None)
+        # enable selection with up and down arrow
+        self.completion.set_inline_selection(True)
+        # It is not possible to change actions later dynamically;
+        # once actions are removed,
+        # they can not be added back (they are not visible).
+        # => nevermind, showing all actions.
+        self.add_action("show all", "Show all activities")
+        self.add_action("filter on category", "Filter on selected category")
 
         self.connect("icon-release", self.on_icon_release)
         self.connect("focus-in-event", self.on_focus_in_event)
         self.completion.connect('match-selected', self.on_match_selected)
+        self.completion.connect("action_activated", self.on_action_activated)
+
+    def add_action(self, name, text):
+        """Add an action to the suggestions.
+
+        name (str): unique label, use to retrieve the action index.
+        text (str): text used to display the action.
+        """
+        markup = "<i>{}</i>".format(stuff.escape_pango(text))
+        idx = len(self._action_list)
+        self.completion.insert_action_markup(idx, markup)
+        self._action_list.append(name)
+
+    def clear(self, notify=True):
+        self.widget.set_text("")
+        if notify:
+            self.emit("changed")
+
+    def clear_actions(self):
+        """Remove all actions from the suggestion list."""
+        while self._action_list:
+            idx_last = len(self._action_list) - 1
+            self.completion.delete_action(idx_last)
+            self._action_list.pop(idx_last)
 
     def match_func(self, completion, key, iter, *user_data):
         if not key.strip():
@@ -513,6 +549,17 @@ class ActivityEntry():
             key_in_category = stripped_key in categories
             return key_in_activity or key_in_category
 
+    def on_action_activated(self, completion, index):
+        name = self._action_list[index]
+        if name == "clear":
+            self.clear(notify=False)
+        elif name == "show all":
+            self.filter_on_category = False
+            self.populate_completions()
+        elif name == "filter on category":
+            self.filter_on_category = True
+            self.populate_completions()
+
     def on_focus_in_event(self, widget, event):
         self.populate_completions()
 
@@ -527,20 +574,31 @@ class ActivityEntry():
         combined = model[iter][self.text_column]
         if self.category_widget:
             self.set_text(activity_name)
-            self.category_widget.set_text(category_name)
+            if not self.filter_on_category:
+                self.category_widget.set_text(category_name)
         else:
             self.set_text(combined)
         return True  # prevent the standard callback from overwriting text
 
     def populate_completions(self):
         self.model.clear()
-        for category in runtime.storage.get_categories():
-            category_name = category['name']
-            category_id = category['id']
-            for activity in runtime.storage.get_category_activities(category_id):
+        if self.filter_on_category:
+            category_names = [self.category_widget.get_text()]
+        else:
+            category_names = [category['name']
+                              for category in runtime.storage.get_categories()]
+        for category_name in category_names:
+            category_id = runtime.storage.get_category_id(category_name)
+            activities = runtime.storage.get_category_activities(category_id)
+            for activity in activities:
                 activity_name = activity["name"]
                 text = "{}@{}".format(activity_name, category_name)
                 self.model.append([text, activity_name, category_name])
+
+    def remove_action(self, name):
+        idx = self._action_list.find(name)
+        self.completion.delete_action(idx)
+        del(self._action_list[idx])
 
     def __getattr__(self, name):
         return getattr(self.widget, name)
@@ -574,7 +632,7 @@ class CategoryEntry():
         self.widget.connect("focus-in-event", self.on_focus_in_event)
         self.completion.connect("action_activated", self.on_action_activated)
 
-    def clear(self, notify):
+    def clear(self, notify=True):
         self.widget.set_text("")
         if notify:
             self.emit("changed")
@@ -597,10 +655,8 @@ class CategoryEntry():
 
     def on_icon_release(self, entry, icon_pos, event):
         self.widget.grab_focus()
-
         # do not emit changed on the primary (clear) button
-        self.clear(icon_pos == gtk.EntryIconPosition.SECONDARY)
-
+        self.clear()
 
     def populate_completions(self):
         self.model.clear()

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -199,7 +199,7 @@ class CompleteTree(graphics.Scene):
 
 
 
-class ActivityEntry(gtk.Entry):
+class CmdLineEntry(gtk.Entry):
     def __init__(self, updating=True, **kwargs):
         gtk.Entry.__init__(self)
 

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -528,13 +528,6 @@ class ActivityEntry():
         if notify:
             self.emit("changed")
 
-    def clear_actions(self):
-        """Remove all actions from the suggestion list."""
-        while self._action_list:
-            idx_last = len(self._action_list) - 1
-            self.completion.delete_action(idx_last)
-            self._action_list.pop(idx_last)
-
     def match_func(self, completion, key, iter, *user_data):
         if not key.strip():
             # show all keys if entry is empty
@@ -594,11 +587,6 @@ class ActivityEntry():
                 activity_name = activity["name"]
                 text = "{}@{}".format(activity_name, category_name)
                 self.model.append([text, activity_name, category_name])
-
-    def remove_action(self, name):
-        idx = self._action_list.find(name)
-        self.completion.delete_action(idx)
-        del(self._action_list[idx])
 
     def __getattr__(self, name):
         return getattr(self.widget, name)

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -531,7 +531,6 @@ class ActivityEntry():
         for category in runtime.storage.get_categories():
             category_name = category['name']
             category_id = category['id']
-            c_iter = self.model.append(["", category_name, "@{}".format(category_name)])
             for activity in runtime.storage.get_category_activities(category_id):
                 activity_name = activity["name"]
                 text = "{}@{}".format(activity_name, category_name)

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -466,9 +466,13 @@ class CmdLineEntry(gtk.Entry):
 
 
 class ActivityEntry():
-    """Category entry widget."""
+    """Activity entry widget.
+
+    widget (gtk.Entry): the associated activity entry
+    category_widget (gtk.Entry): the associated category entry
+    """
     def __init__(self, widget=None, category_widget=None, **kwds):
-        # widget and completion are already defined
+        # widget and completion may be defined already
         # e.g. in the glade edit_activity.ui file
         self.widget = widget
         if not self.widget:
@@ -499,7 +503,8 @@ class ActivityEntry():
             # show all keys if entry is empty
             return True
         else:
-            # return if the entered string is anywhere in the first column data
+            # return whether the entered string is
+            # anywhere in the first column data
             stripped_key = key.strip()
             activities = self.model.get_value(iter, self.activity_column).lower()
             categories = self.model.get_value(iter, self.category_column).lower()
@@ -541,7 +546,10 @@ class ActivityEntry():
 
 
 class CategoryEntry():
-    """Category entry widget."""
+    """Category entry widget.
+
+    widget (gtk.Entry): the associated category entry
+    """
     def __init__(self, widget=None, **kwds):
         # widget and completion are already defined
         # e.g. in the glade edit_activity.ui file
@@ -567,7 +575,8 @@ class CategoryEntry():
             # show all keys if entry is empty
             return True
         else:
-            # return if the entered string is anywhere in the first column data
+            # return whether the entered string is
+            # anywhere in the first column data
             return key.strip() in self.model.get_value(iter, 0)
 
     def on_focus_in_event(self, widget, event):

--- a/src/hamster/widgets/dates.py
+++ b/src/hamster/widgets/dates.py
@@ -32,10 +32,16 @@ from hamster.lib.configuration import load_ui_file
 class Calendar():
     """Python date interface to a Gtk.Calendar.
 
-    widget (Gtk.Calendar): the associated Gtk widget.
+    widget (Gtk.Calendar):
+        the associated Gtk widget.
+    expander (Gtk.expander):
+        An optional expander which contains the widget.
+        The expander label displays the date.
     """
-    def __init__(self, widget):
+    def __init__(self, widget, expander=None):
         self.widget = widget
+        self.expander = expander
+        self.widget.connect("day-selected", self.on_date_changed)
 
     @property
     def date(self):
@@ -61,6 +67,13 @@ class Calendar():
             day = value.day
             self.widget.select_month(month, year)
             self.widget.select_day(day)
+
+    def on_date_changed(self, widget):
+        if self.expander:
+            if self.date:
+                self.expander.set_label(self.date.strftime("%A %Y-%m-%d"))
+            else:
+                self.expander.set_label("")
 
     def __getattr__(self, name):
         return getattr(self.widget, name)

--- a/src/hamster/widgets/dates.py
+++ b/src/hamster/widgets/dates.py
@@ -62,6 +62,9 @@ class Calendar():
             self.widget.select_month(month, year)
             self.widget.select_day(day)
 
+    def __getattr__(self, name):
+        return getattr(self.widget, name)
+
 
 class RangePick(gtk.ToggleButton):
     """ a text entry widget with calendar popup"""

--- a/src/hamster/widgets/dates.py
+++ b/src/hamster/widgets/dates.py
@@ -28,6 +28,41 @@ import re
 from hamster.lib import stuff
 from hamster.lib.configuration import load_ui_file
 
+
+class Calendar():
+    """Python date interface to a Gtk.Calendar.
+
+    widget (Gtk.Calendar): the associated Gtk widget.
+    """
+    def __init__(self, widget):
+        self.widget = widget
+
+    @property
+    def date(self):
+        """Selected day, as datetime.date."""
+        year, month, day = self.widget.get_date()
+        # months start at 0 in Gtk.Calendar and at 1 in python date
+        month += 1
+        return dt.date(year=year, month=month, day=day) if day else None
+
+    @date.setter
+    def date(self, value):
+        """Set date.
+
+        value can be a python date or datetime.
+        """
+        if value is None:
+            # unselect day
+            self.widget.select_day(0)
+        else:
+            year = value.year
+            # months start at 0 in Gtk.Calendar and at 1 in python date
+            month = value.month - 1
+            day = value.day
+            self.widget.select_month(month, year)
+            self.widget.select_day(day)
+
+
 class RangePick(gtk.ToggleButton):
     """ a text entry widget with calendar popup"""
     __gsignals__ = {

--- a/src/hamster/widgets/tags.py
+++ b/src/hamster/widgets/tags.py
@@ -149,7 +149,8 @@ class TagsEntry(gtk.Entry):
         self.categories = None
 
     def populate_suggestions(self):
-        self.ac_tags = self.ac_tags or [tag["name"] for tag in runtime.storage.get_tags(only_autocomplete=True)]
+        self.ac_tags = self.ac_tags or [tag["name"] for tag in
+                                        runtime.storage.get_tags(only_autocomplete=True)]
 
         cursor_tag = self.get_cursor_tag()
 

--- a/src/hamster/widgets/tags.py
+++ b/src/hamster/widgets/tags.py
@@ -18,6 +18,7 @@
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
 from gi.repository import GObject as gobject
+from gi.repository import Gdk as gdk
 from gi.repository import Gtk as gtk
 from gi.repository import Pango as pango
 import cairo
@@ -33,7 +34,7 @@ class TagsEntry(gtk.Entry):
 
     def __init__(self):
         gtk.Entry.__init__(self)
-        self.tags = None
+        self.ac_tags = None  # "autocomplete" tags
         self.filter = None # currently applied filter string
         self.filter_tags = [] #filtered tags
 
@@ -53,7 +54,9 @@ class TagsEntry(gtk.Entry):
         self.scroll_box.add(viewport)
         self.popup.add(self.scroll_box)
 
-        self.connect("button-press-event", self._on_button_press_event)
+        self.set_icon_from_icon_name(gtk.EntryIconPosition.SECONDARY, "go-down-symbolic")
+
+        self.connect("icon-press", self._on_icon_press)
         self.connect("key-press-event", self._on_key_press_event)
         self.connect("key-release-event", self._on_key_release_event)
         self.connect("focus-out-event", self._on_focus_out_event)
@@ -61,7 +64,7 @@ class TagsEntry(gtk.Entry):
         self._parent_click_watcher = None # bit lame but works
 
         self.external_listeners = [
-            (runtime.storage, runtime.storage.connect('tags-changed', self.refresh_tags))
+            (runtime.storage, runtime.storage.connect('tags-changed', self.refresh_ac_tags))
         ]
         self.show()
         self.populate_suggestions()
@@ -74,8 +77,8 @@ class TagsEntry(gtk.Entry):
         self.popup = None
 
 
-    def refresh_tags(self, event):
-        self.tags = None
+    def refresh_ac_tags(self, event):
+        self.ac_tags = None
 
     def get_tags(self):
         # splits the string by comma and filters out blanks
@@ -93,8 +96,8 @@ class TagsEntry(gtk.Entry):
         self.tag_box.selected_tags = tags
 
 
-        self.set_text("%s, " % ", ".join(tags))
-        self.set_position(len(self.get_text()))
+        self.set_tags(tags)
+        self.update_tagsline(add=True)
 
         self.populate_suggestions()
         self.show_popup()
@@ -106,9 +109,8 @@ class TagsEntry(gtk.Entry):
 
         self.tag_box.selected_tags = tags
 
-        self.set_text("%s, " % ", ".join(tags))
-        self.set_position(len(self.get_text()))
-
+        self.set_tags(tags)
+        self.update_tagsline(add=True)
 
     def hide_popup(self):
         self.popup.hide()
@@ -125,7 +127,7 @@ class TagsEntry(gtk.Entry):
             self._parent_click_watcher = self.get_toplevel().connect("button-press-event", self._on_focus_out_event)
 
         alloc = self.get_allocation()
-        x, y = self.get_parent_window().get_origin()
+        _, x, y = self.get_parent_window().get_origin()
 
         self.popup.move(x + alloc.x,y + alloc.y + alloc.height)
 
@@ -134,7 +136,7 @@ class TagsEntry(gtk.Entry):
         height = self.tag_box.count_height(w)
 
 
-        self.tag_box.modify_bg(gtk.StateType.NORMAL, "#eee") #self.get_style().base[gtk.StateType.NORMAL])
+        #self.tag_box.modify_bg(gtk.StateType.NORMAL, "#eee") #self.get_style().base[gtk.StateType.NORMAL])
 
         self.scroll_box.set_size_request(w, height)
         self.popup.resize(w, height)
@@ -151,7 +153,7 @@ class TagsEntry(gtk.Entry):
         self.categories = None
 
     def populate_suggestions(self):
-        self.tags = self.tags or [tag["name"] for tag in runtime.storage.get_tags(only_autocomplete=True)]
+        self.ac_tags = self.ac_tags or [tag["name"] for tag in runtime.storage.get_tags(only_autocomplete=True)]
 
         cursor_tag = self.get_cursor_tag()
 
@@ -160,7 +162,8 @@ class TagsEntry(gtk.Entry):
         entered_tags = self.get_tags()
         self.tag_box.selected_tags = entered_tags
 
-        self.filter_tags = [tag for tag in self.tags if (tag or "").lower().startswith((self.filter or "").lower())]
+        self.filter_tags = [tag for tag in self.ac_tags
+                            if (tag or "").lower().startswith((self.filter or "").lower())]
 
         self.tag_box.draw(self.filter_tags)
 
@@ -169,9 +172,17 @@ class TagsEntry(gtk.Entry):
     def _on_focus_out_event(self, widget, event):
         self.hide_popup()
 
-    def _on_button_press_event(self, button, event):
-        self.populate_suggestions()
-        self.show_popup()
+    def _on_icon_press(self, entry, icon_pos, event):
+        # toggle popup
+        if self.popup.get_visible():
+            # remove trailing comma is any
+            self.update_tagsline(add=False)
+            self.hide_popup()
+        else:
+            # add trailing comma
+            self.update_tagsline(add=True)
+            self.populate_suggestions()
+            self.show_popup()
 
     def _on_key_release_event(self, entry, event):
         if (event.keyval in (gdk.KEY_Return, gdk.KEY_KP_Enter)):
@@ -219,7 +230,18 @@ class TagsEntry(gtk.Entry):
         else:
             cursor = self.get_position()
 
-        self.set_text(", ".join(tags))
+        self.set_tags(tags)
+        self.set_position(len(self.get_text()))
+
+    def set_tags(self, tags):
+        self.tags = tags
+        self.update_tagsline()
+
+    def update_tagsline(self, add=False):
+        text = ", ".join(self.tags)
+        if add and text:
+            text = "{}, ".format(text)
+        self.set_text(text)
         self.set_position(len(self.get_text()))
 
     def _on_key_press_event(self, entry, event):

--- a/src/hamster/widgets/tags.py
+++ b/src/hamster/widgets/tags.py
@@ -58,7 +58,6 @@ class TagsEntry(gtk.Entry):
 
         self.connect("icon-press", self._on_icon_press)
         self.connect("key-press-event", self._on_key_press_event)
-        self.connect("key-release-event", self._on_key_release_event)
         self.connect("focus-out-event", self._on_focus_out_event)
 
         self._parent_click_watcher = None # bit lame but works
@@ -181,30 +180,6 @@ class TagsEntry(gtk.Entry):
             self.populate_suggestions()
             self.show_popup()
 
-    def _on_key_release_event(self, entry, event):
-        if (event.keyval in (gdk.KEY_Return, gdk.KEY_KP_Enter)):
-            if self.popup.get_property("visible"):
-                if self.get_text():
-                    self.hide_popup()
-                return True
-            else:
-                if self.get_text():
-                    self.emit("tags-selected")
-                return False
-        elif (event.keyval == gdk.KEY_Escape):
-            if self.popup.get_property("visible"):
-                self.hide_popup()
-                return True
-            else:
-                return False
-        else:
-            self.populate_suggestions()
-            self.show_popup()
-
-            if event.keyval not in (gdk.KEY_Delete, gdk.KEY_BackSpace):
-                self.complete_inline()
-
-
     def get_cursor_tag(self):
         #returns the tag on which the cursor is on right now
         if self.get_selection_bounds():
@@ -252,6 +227,30 @@ class TagsEntry(gtk.Entry):
                     return False
             else:
                 return False
+
+        elif event.keyval in (gdk.KEY_Return, gdk.KEY_KP_Enter):
+            if self.popup.get_property("visible"):
+                if self.get_text():
+                    self.hide_popup()
+                return True
+            else:
+                if self.get_text():
+                    self.emit("tags-selected")
+                return False
+
+        elif event.keyval == gdk.KEY_Escape:
+            if self.popup.get_property("visible"):
+                self.hide_popup()
+                return True
+            else:
+                return False
+
+        else:
+            self.populate_suggestions()
+            self.show_popup()
+
+            if event.keyval not in (gdk.KEY_Delete, gdk.KEY_BackSpace):
+                self.complete_inline()
 
         return False
 

--- a/src/hamster/widgets/tags.py
+++ b/src/hamster/widgets/tags.py
@@ -136,7 +136,8 @@ class TagsEntry(gtk.Entry):
         height = self.tag_box.count_height(w)
 
 
-        #self.tag_box.modify_bg(gtk.StateType.NORMAL, "#eee") #self.get_style().base[gtk.StateType.NORMAL])
+        _, color = gdk.Color.parse("#000")
+        self.tag_box.modify_bg(gtk.StateType.NORMAL, color) #self.get_style().base[gtk.StateType.NORMAL])
 
         self.scroll_box.set_size_request(w, height)
         self.popup.resize(w, height)

--- a/src/hamster/widgets/tags.py
+++ b/src/hamster/widgets/tags.py
@@ -174,7 +174,7 @@ class TagsEntry(gtk.Entry):
         self.grab_focus()
         # toggle popup
         if self.popup.get_visible():
-            # remove trailing comma is any
+            # remove trailing comma if any
             self.update_tagsline(add=False)
             self.hide_popup()
         else:
@@ -213,6 +213,11 @@ class TagsEntry(gtk.Entry):
         self.update_tagsline()
 
     def update_tagsline(self, add=False):
+        """Update tags line text.
+
+        If add is True, prepare to add tags to the list:
+        a comma is appended and the popup is displayed.
+        """
         text = ", ".join(self.tags)
         if add and text:
             text = "{}, ".format(text)

--- a/src/hamster/widgets/tags.py
+++ b/src/hamster/widgets/tags.py
@@ -135,10 +135,6 @@ class TagsEntry(gtk.Entry):
 
         height = self.tag_box.count_height(w)
 
-
-        _, color = gdk.Color.parse("#000")
-        self.tag_box.modify_bg(gtk.StateType.NORMAL, color) #self.get_style().base[gtk.StateType.NORMAL])
-
         self.scroll_box.set_size_request(w, height)
         self.popup.resize(w, height)
         self.popup.show_all()

--- a/src/hamster/widgets/tags.py
+++ b/src/hamster/widgets/tags.py
@@ -138,11 +138,6 @@ class TagsEntry(gtk.Entry):
         self.popup.resize(w, height)
         self.popup.show_all()
 
-
-
-    def complete_inline(self):
-        return
-
     def refresh_activities(self):
         # scratch activities and categories so that they get repopulated on demand
         self.activities = None
@@ -256,9 +251,6 @@ class TagsEntry(gtk.Entry):
         else:
             self.populate_suggestions()
             self.show_popup()
-
-            if event.keyval not in (gdk.KEY_Delete, gdk.KEY_BackSpace):
-                self.complete_inline()
 
         return False
 

--- a/src/hamster/widgets/tags.py
+++ b/src/hamster/widgets/tags.py
@@ -169,6 +169,8 @@ class TagsEntry(gtk.Entry):
         self.hide_popup()
 
     def _on_icon_press(self, entry, icon_pos, event):
+        # otherwise Esc could not hide popup
+        self.grab_focus()
         # toggle popup
         if self.popup.get_visible():
             # remove trailing comma is any

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -197,10 +197,12 @@ class TimeInput(gtk.Entry):
         if self.start_time is None:
             # full 24 hours
             i_time = i_time_0
+            interval = dt.timedelta(minutes = 15)
             end_time = i_time_0 + dt.timedelta(days = 1)
         else:
             # from start time to start time + 12 hours
-            i_time = i_time_0 + dt.timedelta(minutes = 15)
+            interval = dt.timedelta(minutes = 15)
+            i_time = i_time_0 + interval
             end_time = i_time_0 + dt.timedelta(hours = 12)
 
         time = self.figure_time(self.get_text())
@@ -217,14 +219,10 @@ class TimeInput(gtk.Entry):
 
             hours.append([row_text])
 
-            if focus_time and i_time <= focus_time <= i_time + \
-                                                     dt.timedelta(minutes = 30):
+            if focus_time and i_time <= focus_time < i_time + interval:
                 focus_row = i
 
-            if self.start_time is None:
-                i_time += dt.timedelta(minutes = 30)
-            else:
-                i_time += dt.timedelta(minutes = 15)
+            i_time += interval
 
             i += 1
 

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -273,18 +273,18 @@ class TimeInput(gtk.Entry):
 
 
         i = model.get_path(iter)[0]
-        if event.keyval == gtk.gdk.KEY_Up:
+        if event.keyval == gdk.KEY_Up:
             i-=1
-        elif event.keyval == gtk.gdk.KEY_Down:
+        elif event.keyval == gdk.KEY_Down:
             i+=1
-        elif (event.keyval == gtk.gdk.KEY_Return or
-              event.keyval == gtk.gdk.KEY_KP_Enter):
+        elif (event.keyval == gdk.KEY_Return or
+              event.keyval == gdk.KEY_KP_Enter):
 
             if self.popup.get_property("visible"):
                 self._select_time(self.time_tree.get_model()[i][0])
             else:
                 self._select_time(entry.get_text())
-        elif (event.keyval == gtk.gdk.KEY_Escape):
+        elif (event.keyval == gdk.KEY_Escape):
             self.hide_popup()
             return
 
@@ -295,7 +295,7 @@ class TimeInput(gtk.Entry):
         self.time_tree.scroll_to_cell(i, use_align = True, row_align = 0.4)
 
         # if popup is not visible, display it on up and down
-        if event.keyval in (gtk.gdk.KEY_Up, gtk.gdk.KEY_Down) and self.popup.props.visible == False:
+        if event.keyval in (gdk.KEY_Up, gdk.KEY_Down) and self.popup.props.visible == False:
             self.show_popup()
 
         return True

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -60,7 +60,7 @@ class TimeInput(gtk.Entry):
         time_box.add(self.time_tree)
         self.popup.add(time_box)
 
-        self.set_icon_from_icon_name(gtk.EntryIconPosition.PRIMARY, "edit-delete")
+        self.set_icon_from_icon_name(gtk.EntryIconPosition.PRIMARY, "edit-clear-all-symbolic")
         self.set_icon_from_icon_name(gtk.EntryIconPosition.SECONDARY, "go-down-symbolic")
 
         self.connect("icon-release", self._on_icon_release)

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -236,12 +236,9 @@ class TimeInput(gtk.Entry):
             selection.select_path(focus_row)
             self.time_tree.scroll_to_cell(focus_row, use_align = True, row_align = 0.4)
 
-
         #move popup under the widget
         alloc = self.get_allocation()
         w = alloc.width
-        if self.start_time is not None:
-            w = w * 2
         self.time_tree.set_size_request(w, alloc.height * 5)
 
         window = self.get_parent_window()

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -60,6 +60,9 @@ class TimeInput(gtk.Entry):
         time_box.add(self.time_tree)
         self.popup.add(time_box)
 
+        self.set_icon_from_icon_name(gtk.EntryIconPosition.SECONDARY, "gtk-clear")
+
+        self.connect("icon-release", self._on_icon_release)
         self.connect("button-press-event", self._on_button_press_event)
         self.connect("key-press-event", self._on_key_press_event)
         self.connect("focus-in-event", self._on_focus_in_event)
@@ -179,6 +182,11 @@ class TimeInput(gtk.Entry):
         if self.news:
             self.emit("time-entered")
             self.news = False
+
+    def _on_icon_release(self, entry, icon_pos, event):
+        self.grab_focus()
+        self.set_text("")
+        self.emit("changed")
 
     def hide_popup(self):
         if self._parent_click_watcher and self.get_toplevel().handler_is_connected(self._parent_click_watcher):

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -38,7 +38,7 @@ class TimeInput(gtk.Entry):
         self.news = False
         self.set_width_chars(7) #7 is like 11:24pm
 
-        self.set_time(time)
+        self.time = time
         self.set_start_time(start_time)
 
         self.popup = gtk.Window(type = gtk.WindowType.POPUP)
@@ -69,14 +69,20 @@ class TimeInput(gtk.Entry):
         self.show()
         self.connect("destroy", self.on_destroy)
 
+    @property
+    def time(self):
+        """Displayed time (as datetime.time, or None)."""
+        return self.figure_time(self.get_text())
+
+    @time.setter
+    def time(self, value):
+        time = hamster_round(value)
+        self.set_text(self._format_time(time))
+        return time
+
     def on_destroy(self, window):
         self.popup.destroy()
         self.popup = None
-
-    def set_time(self, time):
-        self.time = hamster_round(time)
-
-        self.set_text(self._format_time(time))
 
     def set_start_time(self, start_time):
         """ set the start time. when start time is set, drop down list
@@ -128,11 +134,6 @@ class TimeInput(gtk.Entry):
         if self.news:
             self.emit("time-entered")
             self.news = False
-
-    def get_time(self):
-        self.time = self.figure_time(self.get_text())
-        self.set_text(self._format_time(self.time))
-        return self.time
 
     def _format_time(self, time):
         if time is None:

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -74,11 +74,7 @@ class TimeInput(gtk.Entry):
         self.popup = None
 
     def set_time(self, time):
-        time = time or dt.time()
-        if isinstance(time, dt.time): # ensure that we operate with time and strip seconds
-            self.time = dt.time(time.hour, time.minute)
-        else:
-            self.time = dt.time(time.time().hour, time.time().minute)
+        self.time = hamster_round(time)
 
         self.set_text(self._format_time(time))
 
@@ -87,11 +83,10 @@ class TimeInput(gtk.Entry):
             will start from start time and duration will be displayed in
             brackets
         """
-        if start_time is not None:
-            start_time = hamster_round(start_time)
-            if isinstance(start_time, dt.datetime):
-                # timeinput works on time only
-                start_time = start_time.time()
+        start_time = hamster_round(start_time)
+        if isinstance(start_time, dt.datetime):
+            # timeinput works on time only
+            start_time = start_time.time()
         self.start_time = start_time
 
     def _on_text_changed(self, widget):
@@ -99,7 +94,7 @@ class TimeInput(gtk.Entry):
 
     def figure_time(self, str_time):
         if not str_time:
-            return self.time
+            return None
 
         # strip everything non-numeric and consider hours to be first number
         # and minutes - second number
@@ -117,7 +112,7 @@ class TimeInput(gtk.Entry):
                 minutes = int(numbers[1])
 
         if (hours is None or minutes is None) or hours > 24 or minutes > 60:
-            return self.time #no can do
+            return None  # no can do
 
         return dt.time(hours, minutes)
 
@@ -179,7 +174,8 @@ class TimeInput(gtk.Entry):
             i_time = i_time_0 + dt.timedelta(minutes = 15)
             end_time = i_time_0 + dt.timedelta(hours = 12)
 
-        focus_time = dt.datetime.combine(dt.date.today(), self.figure_time(self.get_text()))
+        time = self.figure_time(self.get_text())
+        focus_time = dt.datetime.combine(dt.date.today(), time) if time else None
         hours = gtk.ListStore(gobject.TYPE_STRING)
 
         i, focus_row = 0, None

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -60,7 +60,8 @@ class TimeInput(gtk.Entry):
         time_box.add(self.time_tree)
         self.popup.add(time_box)
 
-        self.set_icon_from_icon_name(gtk.EntryIconPosition.SECONDARY, "gtk-clear")
+        self.set_icon_from_icon_name(gtk.EntryIconPosition.PRIMARY, "edit-delete")
+        self.set_icon_from_icon_name(gtk.EntryIconPosition.SECONDARY, "go-down-symbolic")
 
         self.connect("icon-release", self._on_icon_release)
         self.connect("button-press-event", self._on_button_press_event)
@@ -185,8 +186,12 @@ class TimeInput(gtk.Entry):
 
     def _on_icon_release(self, entry, icon_pos, event):
         self.grab_focus()
-        self.set_text("")
-        self.emit("changed")
+        if icon_pos == gtk.EntryIconPosition.PRIMARY:
+            # "clear" button
+            self.set_text("")
+            self.emit("changed")
+        else:
+            self.toggle_popup()
 
     def hide_popup(self):
         if self._parent_click_watcher and self.get_toplevel().handler_is_connected(self._parent_click_watcher):
@@ -254,6 +259,11 @@ class TimeInput(gtk.Entry):
         self.popup.resize(*self.time_tree.get_size_request())
         self.popup.show_all()
 
+    def toggle_popup(self):
+        if self.popup.get_property("visible"):
+            self.hide_popup()
+        else:
+            self.show_popup()
 
     def _on_time_tree_button_press_event(self, tree, event):
         model, iter = tree.get_selection().get_selected()

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -205,7 +205,7 @@ class TimeInput(gtk.Entry):
 
         time = self.figure_time(self.get_text())
         focus_time = dt.datetime.combine(dt.date.today(), time) if time else None
-        hours = gtk.ListStore(gobject.TYPE_STRING)
+        hours = gtk.ListStore(str)
 
         i, focus_row = 0, None
         while i_time < end_time:

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -61,7 +61,6 @@ class TimeInput(gtk.Entry):
         self.popup.add(time_box)
 
         self.set_icon_from_icon_name(gtk.EntryIconPosition.PRIMARY, "edit-clear-all-symbolic")
-        self.set_icon_from_icon_name(gtk.EntryIconPosition.SECONDARY, "go-down-symbolic")
 
         self.connect("icon-release", self._on_icon_release)
         self.connect("button-press-event", self._on_button_press_event)
@@ -186,12 +185,8 @@ class TimeInput(gtk.Entry):
 
     def _on_icon_release(self, entry, icon_pos, event):
         self.grab_focus()
-        if icon_pos == gtk.EntryIconPosition.PRIMARY:
-            # "clear" button
-            self.set_text("")
-            self.emit("changed")
-        else:
-            self.toggle_popup()
+        self.set_text("")
+        self.emit("changed")
 
     def hide_popup(self):
         if self._parent_click_watcher and self.get_toplevel().handler_is_connected(self._parent_click_watcher):

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -169,6 +169,9 @@ class TestActivityInputParsing(unittest.TestCase):
         # space between category and tag
         fact2 = Fact.parse("11:00 12:00 BPC-261 - Task title@Project #code")
         self.assertEqual(fact.serialized(), fact2.serialized())
+        # empty fact
+        fact3 = Fact()
+        self.assertEqual(fact3.serialized(), "")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR is first step towards verbatim entry.
To fix #280 and #423 some changes will be required in db.py (working on it).

Meanwhile, using completion code/widgets that were still around,
this PR brings back separate field entries, 
as well as completion for time, activity, category and tags.
That should fix #301 and #439.

![Screenshot_20191005_224618](https://user-images.githubusercontent.com/10962809/66260672-f2d10600-e7c1-11e9-9e45-5d75d938e8e5.png)


Feedback welcome !

To do:
- [x] End time popup is too large
- [x] Fix empty start time issues
- [x] Find more standard icons, and/or check icons availability, provide fallback ? cf. https://github.com/projecthamster/hamster/pull/461#issuecomment-541577877
- [x] separate "go-down-symbolic" and clear icons