### PR TITLE
Verbatim database read/write

### DIFF
--- a/src/hamster-service
+++ b/src/hamster-service
@@ -168,6 +168,14 @@ class Storage(db.Storage, dbus.service.Object):
         if end_time:
             end_time = dt.datetime.utcfromtimestamp(end_time)
         return self.update_fact(fact_id, fact, start_time, end_time, temporary) or 0
+    
+    
+    @dbus.service.method("org.gnome.Hamster",
+                         in_signature='i{}'.format(fact_signature),
+                         out_signature='i')
+    def UpdateFactVerbatim(self, fact_id, dbus_fact):
+        fact = from_dbus_fact(dbus_fact)
+        return self.update_fact(fact_id, fact) or 0
 
 
     @dbus.service.method("org.gnome.Hamster", in_signature='i')

--- a/src/hamster-service
+++ b/src/hamster-service
@@ -18,7 +18,7 @@ from hamster.lib.dbus import (
     dbus,
     fact_signature,
     from_dbus_fact,
-    to_dbus_fact_verbatim
+    to_dbus_fact
 )
 
 logger = default_logger(__file__)
@@ -153,7 +153,7 @@ class Storage(db.Storage, dbus.service.Object):
     def GetFact(self, fact_id):
         """Get fact by id. For output format see GetFacts"""
         fact = self.get_fact(fact_id)
-        return to_dbus_fact_verbatim(fact)
+        return to_dbus_fact(fact)
 
 
     @dbus.service.method("org.gnome.Hamster", in_signature='isiib', out_signature='i')
@@ -211,14 +211,14 @@ class Storage(db.Storage, dbus.service.Object):
         if end_date:
             end = dt.datetime.utcfromtimestamp(end_date).date()
 
-        return [to_dbus_fact_verbatim(fact) for fact in self.get_facts(start, end, search_terms)]
+        return [to_dbus_fact(fact) for fact in self.get_facts(start, end, search_terms)]
 
 
     @dbus.service.method("org.gnome.Hamster", out_signature='a{}'.format(fact_signature))
     def GetTodaysFacts(self):
         """Gets facts of today, respecting hamster midnight. See GetFacts for
         return info"""
-        return [to_dbus_fact_verbatim(fact) for fact in self.get_todays_facts()]
+        return [to_dbus_fact(fact) for fact in self.get_todays_facts()]
 
 
     # categories

--- a/src/hamster-service
+++ b/src/hamster-service
@@ -153,7 +153,7 @@ class Storage(db.Storage, dbus.service.Object):
         end_time = end_time or None
         if end_time:
             end_time = dt.datetime.utcfromtimestamp(end_time)
-        return self.update_fact(fact_id, fact, start_time, end_time, temporary)
+        return self.update_fact(fact_id, fact, start_time, end_time, temporary) or 0
 
 
     @dbus.service.method("org.gnome.Hamster", in_signature='i')

--- a/src/hamster-service
+++ b/src/hamster-service
@@ -18,7 +18,8 @@ from hamster.lib.dbus import (
     dbus,
     fact_signature,
     from_dbus_fact,
-    to_dbus_fact
+    to_dbus_fact,
+    to_dbus_fact_verbatim
 )
 
 logger = default_logger(__file__)
@@ -152,10 +153,8 @@ class Storage(db.Storage, dbus.service.Object):
                          out_signature=fact_signature)
     def GetFact(self, fact_id):
         """Get fact by id. For output format see GetFacts"""
-        fact = dict(self.get_fact(fact_id))
-        fact['date'] = fact['start_time'].date()
-        fact['delta'] = dt.timedelta()
-        return to_dbus_fact(fact)
+        fact = self.get_fact(fact_id)
+        return to_dbus_fact_verbatim(fact)
 
 
     @dbus.service.method("org.gnome.Hamster", in_signature='isiib', out_signature='i')

--- a/src/hamster-service
+++ b/src/hamster-service
@@ -13,7 +13,13 @@ i18n.setup_i18n()
 
 from hamster.storage import db
 from hamster.lib import default_logger, desktop, Fact, stuff
-from hamster.lib.dbus import DBusMainLoop, dbus, fact_signature, to_dbus_fact
+from hamster.lib.dbus import (
+    DBusMainLoop,
+    dbus,
+    fact_signature,
+    from_dbus_fact,
+    to_dbus_fact
+)
 
 logger = default_logger(__file__)
 
@@ -132,6 +138,12 @@ class Storage(db.Storage, dbus.service.Object):
         fact.start_time = dt.datetime.utcfromtimestamp(start_time) if start_time else None
         fact.end_time = dt.datetime.utcfromtimestamp(end_time) if end_time else None
         
+        return self.add_fact(fact) or 0
+
+
+    @dbus.service.method("org.gnome.Hamster", in_signature=fact_signature, out_signature='i')
+    def AddFactVerbatim(self, dbus_fact):
+        fact = from_dbus_fact(dbus_fact)
         return self.add_fact(fact) or 0
 
 

--- a/src/hamster-service
+++ b/src/hamster-service
@@ -4,18 +4,8 @@
 import logging
 from gi.repository import GLib as glib
 
-import dbus, dbus.service
-from dbus.mainloop.glib import DBusGMainLoop
 import datetime as dt
-from calendar import timegm
 from gi.repository import Gio as gio
-
-DBusGMainLoop(set_as_default=True)
-loop = glib.MainLoop()
-
-if "org.gnome.Hamster" in dbus.SessionBus().list_names():
-    print("Found hamster-service already running, exiting")
-    quit()
 
 from hamster import logger as hamster_logger
 from hamster.lib import i18n
@@ -23,25 +13,17 @@ i18n.setup_i18n()
 
 from hamster.storage import db
 from hamster.lib import default_logger, desktop, stuff
-
+from hamster.lib.dbus import DBusMainLoop, dbus, to_dbus_fact
 
 logger = default_logger(__file__)
 
 
-def to_dbus_fact(fact):
-    """Perform the conversion between fact database query and
-    dbus supported data types
-    """
-    return (fact['id'],
-            timegm(fact['start_time'].timetuple()),
-            timegm(fact['end_time'].timetuple()) if fact['end_time'] else 0,
-            fact['description'] or '',
-            fact['name'] or '',
-            fact['activity_id'] or 0,
-            fact['category'] or '',
-            dbus.Array(fact['tags'], signature = 's'),
-            timegm(fact['date'].timetuple()),
-            fact['delta'].days * 24 * 60 * 60 + fact['delta'].seconds)
+DBusMainLoop(set_as_default=True)
+loop = glib.MainLoop()
+
+if "org.gnome.Hamster" in dbus.SessionBus().list_names():
+    print("Found hamster-service already running, exiting")
+    quit()
 
 
 class Storage(db.Storage, dbus.service.Object):

--- a/src/hamster-service
+++ b/src/hamster-service
@@ -12,7 +12,7 @@ from hamster.lib import i18n
 i18n.setup_i18n()
 
 from hamster.storage import db
-from hamster.lib import default_logger, desktop, stuff
+from hamster.lib import default_logger, desktop, Fact, stuff
 from hamster.lib.dbus import DBusMainLoop, dbus, fact_signature, to_dbus_fact
 
 logger = default_logger(__file__)
@@ -127,10 +127,12 @@ class Storage(db.Storage, dbus.service.Object):
 
     # facts
     @dbus.service.method("org.gnome.Hamster", in_signature='siib', out_signature='i')
-    def AddFact(self, fact, start_time, end_time, temporary = False):
-        start_time = dt.datetime.utcfromtimestamp(start_time) if start_time else None
-        end_time = dt.datetime.utcfromtimestamp(end_time) if end_time else None
-        return self.add_fact(fact, start_time = start_time, end_time = end_time) or 0
+    def AddFact(self, fact_str, start_time, end_time, temporary=False):
+        fact = Fact.parse(fact_str)
+        fact.start_time = dt.datetime.utcfromtimestamp(start_time) if start_time else None
+        fact.end_time = dt.datetime.utcfromtimestamp(end_time) if end_time else None
+        
+        return self.add_fact(fact) or 0
 
 
     @dbus.service.method("org.gnome.Hamster",

--- a/src/hamster-service
+++ b/src/hamster-service
@@ -18,7 +18,6 @@ from hamster.lib.dbus import (
     dbus,
     fact_signature,
     from_dbus_fact,
-    to_dbus_fact,
     to_dbus_fact_verbatim
 )
 
@@ -212,14 +211,14 @@ class Storage(db.Storage, dbus.service.Object):
         if end_date:
             end = dt.datetime.utcfromtimestamp(end_date).date()
 
-        return [to_dbus_fact(fact) for fact in self.get_facts(start, end, search_terms)]
+        return [to_dbus_fact_verbatim(fact) for fact in self.get_facts(start, end, search_terms)]
 
 
     @dbus.service.method("org.gnome.Hamster", out_signature='a{}'.format(fact_signature))
     def GetTodaysFacts(self):
         """Gets facts of today, respecting hamster midnight. See GetFacts for
         return info"""
-        return [to_dbus_fact(fact) for fact in self.get_todays_facts()]
+        return [to_dbus_fact_verbatim(fact) for fact in self.get_todays_facts()]
 
 
     # categories

--- a/src/hamster-service
+++ b/src/hamster-service
@@ -13,7 +13,7 @@ i18n.setup_i18n()
 
 from hamster.storage import db
 from hamster.lib import default_logger, desktop, stuff
-from hamster.lib.dbus import DBusMainLoop, dbus, to_dbus_fact
+from hamster.lib.dbus import DBusMainLoop, dbus, fact_signature, to_dbus_fact
 
 logger = default_logger(__file__)
 
@@ -133,7 +133,9 @@ class Storage(db.Storage, dbus.service.Object):
         return self.add_fact(fact, start_time = start_time, end_time = end_time) or 0
 
 
-    @dbus.service.method("org.gnome.Hamster", in_signature='i', out_signature='(iiissisasii)')
+    @dbus.service.method("org.gnome.Hamster",
+                         in_signature='i',
+                         out_signature=fact_signature)
     def GetFact(self, fact_id):
         """Get fact by id. For output format see GetFacts"""
         fact = dict(self.get_fact(fact_id))
@@ -169,24 +171,16 @@ class Storage(db.Storage, dbus.service.Object):
         return self.remove_fact(fact_id)
 
 
-    @dbus.service.method("org.gnome.Hamster", in_signature='uus', out_signature='a(iiissisasii)')
+    @dbus.service.method("org.gnome.Hamster",
+                         in_signature='uus',
+                         out_signature='a{}'.format(fact_signature))
     def GetFacts(self, start_date, end_date, search_terms):
         """Gets facts between the day of start_date and the day of end_date.
         Parameters:
         i start_date: Seconds since epoch (timestamp). Use 0 for today
         i end_date: Seconds since epoch (timestamp). Use 0 for today
         s search_terms: Bleh. If starts with "not ", the search terms will be reversed
-        Returns Array of fact where fact is struct of:
-            i  id
-            i  start_time
-            i  end_time
-            s  description
-            s  activity name
-            i  activity id
-            s  category name
-            as List of fact tags
-            i  date
-            i  delta
+        Returns an array of D-Bus fact structures.
         """
         #TODO: Assert start > end ?
         start = dt.date.today()
@@ -200,7 +194,7 @@ class Storage(db.Storage, dbus.service.Object):
         return [to_dbus_fact(fact) for fact in self.get_facts(start, end, search_terms)]
 
 
-    @dbus.service.method("org.gnome.Hamster", out_signature='a(iiissisasii)')
+    @dbus.service.method("org.gnome.Hamster", out_signature='a{}'.format(fact_signature))
     def GetTodaysFacts(self):
         """Gets facts of today, respecting hamster midnight. See GetFacts for
         return info"""

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -145,15 +145,12 @@ class Storage(gobject.GObject):
         return from_dbus_fact(self.conn.GetFact(id))
 
     def add_fact(self, fact, temporary_activity = False):
-        """Add fact. activity name can use the
-        `[-]start_time[-end_time] activity@category, description #tag1 #tag2`
-        syntax, or params can be stated explicitly.
-        Params will take precedence over the derived values.
-        start_time defaults to current moment.
-        """
+        """Add fact (Fact)."""
         if not fact.activity:
             return None
 
+        if not fact.start_time:
+            logger.info("Passing fact without any start_time is deprecated")
         serialized = fact.serialized_name()
 
         start_timestamp = timegm((fact.start_time or hamster_now()).timetuple())

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -19,24 +19,10 @@
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import datetime as dt
 from calendar import timegm
-import dbus, dbus.mainloop.glib
 from gi.repository import GObject as gobject
 from hamster.lib import Fact, hamster_now
-
-
-def from_dbus_fact(fact):
-    """unpack the struct into a proper dict"""
-    return Fact(activity=fact[4],
-                start_time=dt.datetime.utcfromtimestamp(fact[1]),
-                end_time=dt.datetime.utcfromtimestamp(fact[2]) if fact[2] else None,
-                description=fact[3],
-                activity_id=fact[5],
-                category=fact[6],
-                tags=fact[7],
-                id=fact[0]
-                )
+from hamster.lib.dbus import DBusMainLoop, dbus, from_dbus_fact
 
 
 class Storage(gobject.GObject):
@@ -62,7 +48,7 @@ class Storage(gobject.GObject):
     def __init__(self):
         gobject.GObject.__init__(self)
 
-        dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+        DBusMainLoop(set_as_default=True)
         self.bus = dbus.SessionBus()
         self._connection = None # will be initiated on demand
 

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -22,7 +22,7 @@
 from calendar import timegm
 from gi.repository import GObject as gobject
 from hamster.lib import Fact, hamster_now
-from hamster.lib.dbus import DBusMainLoop, dbus, from_dbus_fact, to_dbus_fact_verbatim
+from hamster.lib.dbus import DBusMainLoop, dbus, from_dbus_fact, to_dbus_fact
 
 
 class Storage(gobject.GObject):
@@ -152,7 +152,7 @@ class Storage(gobject.GObject):
             logger.info("Adding fact without any start_time is deprecated")
             fact.start_time = hamster_now()
 
-        dbus_fact = to_dbus_fact_verbatim(fact)
+        dbus_fact = to_dbus_fact(fact)
         new_id = self.conn.AddFactVerbatim(dbus_fact)
 
         return new_id
@@ -173,7 +173,7 @@ class Storage(gobject.GObject):
         fact_id after update should not be used anymore. Instead use the ID
         from the fact dict that is returned by this function"""
 
-        dbus_fact = to_dbus_fact_verbatim(fact)
+        dbus_fact = to_dbus_fact(fact)
         new_id =  self.conn.UpdateFactVerbatim(fact_id, dbus_fact)
 
         return new_id

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -173,18 +173,9 @@ class Storage(gobject.GObject):
         fact_id after update should not be used anymore. Instead use the ID
         from the fact dict that is returned by this function"""
 
+        dbus_fact = to_dbus_fact_verbatim(fact)
+        new_id =  self.conn.UpdateFactVerbatim(fact_id, dbus_fact)
 
-        start_time = timegm((fact.start_time or hamster_now()).timetuple())
-
-        end_time = fact.end_time or 0
-        if end_time:
-            end_time = timegm(end_time.timetuple())
-
-        new_id =  self.conn.UpdateFact(fact_id,
-                                       fact.serialized_name(),
-                                       start_time,
-                                       end_time,
-                                       temporary_activity)
         return new_id
 
 

--- a/src/hamster/lib/dbus.py
+++ b/src/hamster/lib/dbus.py
@@ -52,3 +52,21 @@ def to_dbus_fact(fact):
             dbus.Array(fact['tags'], signature = 's'),
             timegm(fact['date'].timetuple()),
             fact['delta'].days * 24 * 60 * 60 + fact['delta'].seconds)
+
+
+# TODO: this one should replace to_dbus_fact once all calls are migrated to use Fact.
+def to_dbus_fact_verbatim(fact):
+    """Perform Fact conversion to D-Bus.
+
+    Return the corresponding dbus structure, with supported data types.
+    """
+    return (fact.id or 0,
+            timegm(fact.start_time.timetuple()),
+            timegm(fact.end_time.timetuple()) if fact.end_time else 0,
+            fact.description or '',
+            fact.activity or '',
+            fact.activity_id or 0,
+            fact.category or '',
+            dbus.Array(fact.tags, signature = 's'),
+            timegm(fact.date.timetuple()),
+            fact.delta.days * 24 * 60 * 60 + fact.delta.seconds)

--- a/src/hamster/lib/dbus.py
+++ b/src/hamster/lib/dbus.py
@@ -38,22 +38,6 @@ def from_dbus_fact(dbus_fact):
                 )
 
 
-def to_dbus_fact(fact):
-    """Perform the conversion between fact database query and
-    dbus supported data types
-    """
-    return (fact['id'],
-            timegm(fact['start_time'].timetuple()),
-            timegm(fact['end_time'].timetuple()) if fact['end_time'] else 0,
-            fact['description'] or '',
-            fact['name'] or '',
-            fact['activity_id'] or 0,
-            fact['category'] or '',
-            dbus.Array(fact['tags'], signature = 's'),
-            timegm(fact['date'].timetuple()),
-            fact['delta'].days * 24 * 60 * 60 + fact['delta'].seconds)
-
-
 # TODO: this one should replace to_dbus_fact once all calls are migrated to use Fact.
 def to_dbus_fact_verbatim(fact):
     """Perform Fact conversion to D-Bus.

--- a/src/hamster/lib/dbus.py
+++ b/src/hamster/lib/dbus.py
@@ -1,0 +1,38 @@
+import datetime as dt
+import dbus
+import dbus.service
+from calendar import timegm
+from dbus.mainloop.glib import DBusGMainLoop as DBusMainLoop
+from hamster.lib import Fact
+
+
+"""D-Bus communication utilities."""
+
+
+def from_dbus_fact(dbus_fact):
+    """unpack the struct into a proper dict"""
+    return Fact(activity=dbus_fact[4],
+                start_time=dt.datetime.utcfromtimestamp(dbus_fact[1]),
+                end_time=dt.datetime.utcfromtimestamp(dbus_fact[2]) if dbus_fact[2] else None,
+                description=dbus_fact[3],
+                activity_id=dbus_fact[5],
+                category=dbus_fact[6],
+                tags=dbus_fact[7],
+                id=dbus_fact[0]
+                )
+
+
+def to_dbus_fact(fact):
+    """Perform the conversion between fact database query and
+    dbus supported data types
+    """
+    return (fact['id'],
+            timegm(fact['start_time'].timetuple()),
+            timegm(fact['end_time'].timetuple()) if fact['end_time'] else 0,
+            fact['description'] or '',
+            fact['name'] or '',
+            fact['activity_id'] or 0,
+            fact['category'] or '',
+            dbus.Array(fact['tags'], signature = 's'),
+            timegm(fact['date'].timetuple()),
+            fact['delta'].days * 24 * 60 * 60 + fact['delta'].seconds)

--- a/src/hamster/lib/dbus.py
+++ b/src/hamster/lib/dbus.py
@@ -38,8 +38,7 @@ def from_dbus_fact(dbus_fact):
                 )
 
 
-# TODO: this one should replace to_dbus_fact once all calls are migrated to use Fact.
-def to_dbus_fact_verbatim(fact):
+def to_dbus_fact(fact):
     """Perform Fact conversion to D-Bus.
 
     Return the corresponding dbus structure, with supported data types.

--- a/src/hamster/lib/dbus.py
+++ b/src/hamster/lib/dbus.py
@@ -9,6 +9,22 @@ from hamster.lib import Fact
 """D-Bus communication utilities."""
 
 
+"""
+dbus_fact signature (types matching the to_dbus_fact output)
+    i  id
+    i  start_time
+    i  end_time
+    s  description
+    s  activity name
+    i  activity id
+    s  category name
+    as List of fact tags
+    i  date
+    i  delta
+"""
+fact_signature = '(iiissisasii)'
+
+
 def from_dbus_fact(dbus_fact):
     """unpack the struct into a proper dict"""
     return Fact(activity=dbus_fact[4],

--- a/src/hamster/lib/desktop.py
+++ b/src/hamster/lib/desktop.py
@@ -74,12 +74,12 @@ class DesktopIntegrations(object):
         last_activity = todays_facts[-1] if todays_facts else None
 
         # update duration of current task
-        if last_activity and not last_activity['end_time']:
-            delta = now - last_activity['start_time']
+        if last_activity and not last_activity.end_time:
+            delta = now - last_activity.start_time
             duration = delta.seconds /  60
 
             if duration and duration % interval == 0:
-                message = _("Working on %s") % last_activity['name']
+                message = _("Working on %s") % last_activity.activity
                 self.notify_user(message)
 
         elif self.conf_notify_on_idle:

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -570,6 +570,7 @@ class Storage(storage.Storage):
                 if previous["activity_id"] == activity_id \
                    and set(previous["tags"]) == set([tag[1] for tag in tags]) \
                    and (previous["description"] or "") == (fact.description or ""):
+                    logger.info("same fact, already on-going, nothing to do")
                     return None
 
                 # if no description is added

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -849,11 +849,12 @@ class Storage(storage.Storage):
                      ORDER BY a.id
             """ % rebuild_ids
 
-            facts = self.__group_tags(self.fetchall(query, (self._unsorted_localized, )))
+            dbfacts = self.__group_tags(self.fetchall(query, (self._unsorted_localized, )))
+            facts = [self._dbfact_to_libfact(dbfact) for dbfact in dbfacts]
 
             insert = """INSERT INTO fact_index (id, name, category, description, tag)
                              VALUES (?, ?, ?, ?, ?)"""
-            params = [(fact['id'], fact['name'], fact['category'], fact['description'], " ".join(fact['tags'])) for fact in facts]
+            params = [(fact.id, fact.name, fact.category, fact.description, " ".join(fact.tags)) for fact in facts]
 
             self.executemany(insert, params)
 

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -531,8 +531,7 @@ class Storage(storage.Storage):
     def __add_fact(self, fact, temporary=False):
         logger.info("adding fact {}".format(fact))
 
-        if not fact.activity or fact.start_time is None:  # sanity check
-            return 0
+        self.validate_fact(fact)  # sanity check
 
         start_time = fact.start_time
         end_time = fact.end_time

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -495,6 +495,7 @@ class Storage(storage.Storage):
                                           start_time, end_time))
 
         for fact in conflicts:
+            # fact is a sqlite.Row, indexable by column name
             fact_end_time = fact["end_time"] or hamster_now()
 
             # won't eliminate as it is better to have overlapping entries than loosing data

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -529,6 +529,18 @@ class Storage(storage.Storage):
 
 
     def __add_fact(self, fact, temporary=False):
+        """Add fact to database.
+
+        Args:
+            fact (Fact)
+        Returns:
+            int, the new fact id in the database (> 0) on success,
+                 0 if nothing needed to be done
+                 (e.g. if the same fact was already on-going),
+                 note: a sanity check on the given fact is performed first,
+                       that would raise an AssertionError.
+                       Other errors would also be handled through exceptions.
+        """
         logger.info("adding fact {}".format(fact))
 
         self.validate_fact(fact)  # sanity check
@@ -571,7 +583,7 @@ class Storage(storage.Storage):
                    and set(previous["tags"]) == set([tag[1] for tag in tags]) \
                    and (previous["description"] or "") == (fact.description or ""):
                     logger.info("same fact, already on-going, nothing to do")
-                    return None
+                    return 0
 
                 # if no description is added
                 # see if maybe previous was too short to qualify as an activity

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -363,6 +363,17 @@ class Storage(storage.Storage):
 
         return None
 
+    def _dbfact_to_libfact(self, db_fact):
+        """Convert a db fact (coming from __group_facts) to Fact."""
+        return Fact(activity=db_fact["name"],
+                    category=db_fact["category"],
+                    description=db_fact["description"],
+                    tags=db_fact["tags"],
+                    start_time=db_fact["start_time"],
+                    end_time=db_fact["end_time"],
+                    id=db_fact["id"],
+                    activity_id=db_fact["activity_id"])
+
     def __get_fact(self, id):
         query = """
                    SELECT a.id AS id,
@@ -383,7 +394,8 @@ class Storage(storage.Storage):
 
         fact_rows = self.fetchall(query, (self._unsorted_localized, id))
         assert len(fact_rows) > 0, "No fact with id {}".format(id)
-        fact = self.__group_tags(fact_rows)[0]
+        dbfact = self.__group_tags(fact_rows)[0]
+        fact = self._dbfact_to_libfact(dbfact)
         logger.info("got fact {}".format(fact))
         return fact
 
@@ -884,7 +896,6 @@ class Storage(storage.Storage):
             params = [(fact['id'], fact['name'], fact['category'], fact['description'], " ".join(fact['tags'])) for fact in facts]
 
             self.executemany(insert, params)
-
 
     """ Here be dragons (lame connection/cursor wrappers) """
     def get_connection(self):

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -502,9 +502,11 @@ class Storage(storage.Storage):
 
                 # create new fact for the end
                 new_fact = Fact(activity=fact["name"],
-                                category = fact["category"],
-                                description = fact["description"])
-                new_fact_id = self.__add_fact(new_fact.serialized_name(), end_time, fact_end_time)
+                                category=fact["category"],
+                                description=fact["description"],
+                                start_time=end_time,
+                                end_time=fact_end_time)
+                new_fact_id = self.__add_fact(new_fact)
 
                 # copy tags
                 tag_update = """INSERT INTO fact_tags(fact_id, tag_id)
@@ -526,19 +528,14 @@ class Storage(storage.Storage):
                              (start_time, fact["id"]))
 
 
-    def __add_fact(self, serialized_fact, start_time, end_time = None, temporary = False):
-        fact = Fact.parse(serialized_fact)
-        fact.start_time = start_time
-        fact.end_time = end_time
-
+    def __add_fact(self, fact, temporary=False):
         logger.info("adding fact {}".format(fact))
 
-        start_time = start_time or fact.start_time
-        end_time = end_time or fact.end_time
-
-        if not fact.activity or start_time is None:  # sanity check
+        if not fact.activity or fact.start_time is None:  # sanity check
             return 0
 
+        start_time = fact.start_time
+        end_time = fact.end_time
 
         # get tags from database - this will create any missing tags too
         tags = [(tag['id'], tag['name'], tag['autocomplete']) for tag in self.get_tag_ids(fact.tags)]

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -381,9 +381,9 @@ class Storage(storage.Storage):
                  ORDER BY e.name
         """
 
-        facts = self.fetchall(query, (self._unsorted_localized, id))
-        assert len(facts) > 0, "No fact with id {}".format(id)
-        fact = self.__group_tags(facts)[0]
+        fact_rows = self.fetchall(query, (self._unsorted_localized, id))
+        assert len(fact_rows) > 0, "No fact with id {}".format(id)
+        fact = self.__group_tags(fact_rows)[0]
         logger.info("got fact {}".format(fact))
         return fact
 
@@ -897,6 +897,11 @@ class Storage(storage.Storage):
     connection = property(get_connection, None)
 
     def fetchall(self, query, params = None):
+        """Execute query.
+
+        Returns:
+            list(sqlite.Row)
+        """
         con = self.connection
         cur = con.cursor()
 

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -80,6 +80,10 @@ class Storage(object):
             self.facts_changed()
         return result
 
+    def validate_fact(self, fact):
+        """Check fact validity for inclusion into storage."""
+        assert fact.activity, "missing activity"
+        assert fact.start_time, "missing start_time"
 
     def stop_tracking(self, end_time):
         """Stops tracking the current activity"""

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -71,14 +71,13 @@ class Storage(object):
         """Get fact by id. For output format see GetFacts"""
         return self.__get_fact(fact_id)
 
-
-    def update_fact(self, fact_id, fact, start_time, end_time, temporary = False):
+    def update_fact(self, fact_id, fact, start_time=None, end_time=None, temporary=False):
         self.start_transaction()
         self.__remove_fact(fact_id)
-        # next 3 lines to be removed once update facts use Fact directly.
+        # to be removed once update facts use Fact directly.
         if isinstance(fact, str):
             fact = Fact.parse(fact)
-        fact = fact.copy(start_time=start_time, end_time=end_time)
+            fact = fact.copy(start_time=start_time, end_time=end_time)
         result = self.__add_fact(fact, temporary)
         if not result:
             logger.warning("failed to update fact {} ({})".format(fact_id, fact))

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -41,16 +41,23 @@ class Storage(object):
 
 
     # facts
-    def add_fact(self, fact, start_time, end_time, temporary = False):
+    def add_fact(self, fact, start_time=None, end_time=None, temporary=False):
         """Add fact.
 
         fact: either a Fact instance or
               a string that can be parsed through Fact.parse.
+
+        note: start_time and end_time are used only when fact is a string,
+              for backward compatibility.
+              Passing fact as a string is deprecated
+              and will be removed in a future version.
+              Parsing should be done in the caller.
         """
         if isinstance(fact, str):
+            logger.info("Passing fact as a string is deprecated")
             fact = Fact.parse(fact)
-
-        fact = fact.copy(start_time=start_time or hamster_now(), end_time=end_time)
+            fact.start_time = start_time
+            fact.end_time = end_time
 
         self.start_transaction()
         result = self.__add_fact(fact, temporary)

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -94,7 +94,7 @@ class Storage(object):
     def stop_tracking(self, end_time):
         """Stops tracking the current activity"""
         facts = self.__get_todays_facts()
-        if facts and not facts[-1]['end_time']:
+        if facts and not facts[-1].end_time:
             self.__touch_fact(facts[-1], end_time)
             self.facts_changed()
 

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -44,14 +44,13 @@ class Storage(object):
         fact: either a Fact instance or
               a string that can be parsed through Fact.parse.
         """
-        if isinstance(fact, Fact):
-            fact_str = fact.serialized_name()
-        else:
-            fact_str = fact
-        start_time = start_time or hamster_now()
+        if isinstance(fact, str):
+            fact = Fact.parse(fact)
+
+        fact = fact.copy(start_time=start_time or hamster_now(), end_time=end_time)
 
         self.start_transaction()
-        result = self.__add_fact(fact_str, start_time, end_time, temporary)
+        result = self.__add_fact(fact, temporary)
         self.end_transaction()
 
         if result:
@@ -66,7 +65,11 @@ class Storage(object):
     def update_fact(self, fact_id, fact, start_time, end_time, temporary = False):
         self.start_transaction()
         self.__remove_fact(fact_id)
-        result = self.__add_fact(fact, start_time, end_time, temporary)
+        # next 3 lines to be removed once update facts use Fact directly.
+        if isinstance(fact, str):
+            fact = Fact.parse(fact)
+        fact = fact.copy(start_time=start_time, end_time=end_time)
+        result = self.__add_fact(fact, temporary)
         self.end_transaction()
         if result:
             self.facts_changed()

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -18,6 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+logger = logging.getLogger(__name__)   # noqa: E402
+
 import datetime as dt
 from hamster.lib import Fact
 from hamster.lib.stuff import hamster_now
@@ -70,6 +73,8 @@ class Storage(object):
             fact = Fact.parse(fact)
         fact = fact.copy(start_time=start_time, end_time=end_time)
         result = self.__add_fact(fact, temporary)
+        if not result:
+            logger.warning("failed to update fact {} ({})".format(fact_id, fact))
         self.end_transaction()
         if result:
             self.facts_changed()


### PR DESCRIPTION
With this PR database read/write is done verbatim, without any parsing involved.
This makes a clear separation of concerns.
It partially solves #280 and #423,
although that requires renouncing to the quickness of the cmdline input, until #465 is solved.

This change should not affect the existing dbus interface (old functions have been kept).
The new `AddFactVerbatim` is strongly encouraged if the caller has separate fields.
The old `AddFact` will remain so that passing a single string will remain possible,
to be interpreted by `Fact.parse` on the hamster side.

Unsorted (no category) facts are not supported yet (forthcoming PR almost ready).