### PR TITLE
Accept activities starting with '#'

### DIFF
--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -337,15 +337,21 @@ def parse_fact(text, phase=None, res=None, date=None):
             if not m:
                 break
             tag = m.group(1)
-            tags.append(tag)
             # strip the matched string (including #)
+            backup_text = remaining_text
             remaining_text = remaining_text[:m.start()]
+            # empty remaining text means that activity is starting with a '#'
+            if remaining_text:
+                tags.append(tag)
+            else:
+                remaining_text = backup_text
+                break
         # put tags back in input order
         res["tags"] = list(reversed(tags))
         return parse_fact(remaining_text, "activity", res, date)
 
     if "activity" in phases:
-        activity = re.split("[@|#|,]", text, 1)[0]
+        activity = re.split("[@|,]", text, 1)[0]
         if looks_like_time(activity):
             # want meaningful activities
             return res

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -23,7 +23,7 @@ TIME_FMT = "%H:%M"
 tag_re = re.compile(r"""
     [\s,]*     # any spaces or commas (or nothing)
     \#          # hash character
-    ([^#\s]+)  # the tag (anything but # or spaces)
+    ([^#\s,]+)  # the tag (anything but #, spaces or comma)
     [\s#,]*    # any spaces, #, or commas (or nothing)
     $           # end of text
 """, flags=re.VERBOSE)

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -82,8 +82,8 @@ class TestActivityInputParsing(unittest.TestCase):
 
     def test_tags(self):
         # plain activity name
-        activity = Fact.parse("case, with added #de description #and, #some #tägs")
-        self.assertEqual(activity.activity, "case")
+        activity = Fact.parse("#case, with added #de description #and, #some #tägs")
+        self.assertEqual(activity.activity, "#case")
         self.assertEqual(activity.description, "with added #de description")
         self.assertEqual(set(activity.tags), set(["and", "some", "tägs"]))
         assert not activity.category


### PR DESCRIPTION
Solves #423.

Note: explicitly forbid comma in tags at parse time
It would be failing anyway during edition of the fact,
because tags entries are based on a comma separated list of tags.