### PR TITLE
Forbid unparseable facts

### DIFF
--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -356,6 +356,11 @@ class CustomFactController(gobject.GObject):
             self.update_status(status="warning", markup=markup)
             return fact
 
+        roundtrip_fact = Fact.parse(fact.serialized())
+        if roundtrip_fact != fact:
+            self.update_status(status="wrong", markup="Fact could not be parsed back")
+            return None
+
         # nothing unusual
         self.update_status(status="looks good", markup="")
         return fact

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -337,15 +337,21 @@ def parse_fact(text, phase=None, res=None, date=None):
             if not m:
                 break
             tag = m.group(1)
-            tags.append(tag)
             # strip the matched string (including #)
+            backup_text = remaining_text
             remaining_text = remaining_text[:m.start()]
+            # empty remaining text means that activity is starting with a '#'
+            if remaining_text:
+                tags.append(tag)
+            else:
+                remaining_text = backup_text
+                break
         # put tags back in input order
         res["tags"] = list(reversed(tags))
         return parse_fact(remaining_text, "activity", res, date)
 
     if "activity" in phases:
-        activity = re.split("[@|#|,]", text, 1)[0]
+        activity = re.split("[@|,]", text, 1)[0]
         if looks_like_time(activity):
             # want meaningful activities
             return res

--- a/src/hamster/lib/__init__.py
+++ b/src/hamster/lib/__init__.py
@@ -23,7 +23,7 @@ TIME_FMT = "%H:%M"
 tag_re = re.compile(r"""
     [\s,]*     # any spaces or commas (or nothing)
     \#          # hash character
-    ([^#\s]+)  # the tag (anything but # or spaces)
+    ([^#\s,]+)  # the tag (anything but #, spaces or comma)
     [\s#,]*    # any spaces, #, or commas (or nothing)
     $           # end of text
 """, flags=re.VERBOSE)

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -82,8 +82,8 @@ class TestActivityInputParsing(unittest.TestCase):
 
     def test_tags(self):
         # plain activity name
-        activity = Fact.parse("case, with added #de description #and, #some #tägs")
-        self.assertEqual(activity.activity, "case")
+        activity = Fact.parse("#case, with added #de description #and, #some #tägs")
+        self.assertEqual(activity.activity, "#case")
         self.assertEqual(activity.description, "with added #de description")
         self.assertEqual(set(activity.tags), set(["and", "some", "tägs"]))
         assert not activity.category


### PR DESCRIPTION
Make the save button active only if the fact entered can be parsed (and thus edited) from the cmdline.
This hopefully answers https://github.com/projecthamster/hamster/pull/461#issuecomment-549302989 favorably, while waiting for #465.

The first two commit are from PR #475, only a544d5e is added by this PR.