### PR TITLE
Convert to int in fact_from_dbus

### DIFF
--- a/src/hamster/lib/dbus.py
+++ b/src/hamster/lib/dbus.py
@@ -28,13 +28,13 @@ fact_signature = '(iiissisasii)'
 def from_dbus_fact(dbus_fact):
     """unpack the struct into a proper dict"""
     return Fact(activity=dbus_fact[4],
-                start_time=dt.datetime.utcfromtimestamp(dbus_fact[1]),
-                end_time=dt.datetime.utcfromtimestamp(dbus_fact[2]) if dbus_fact[2] else None,
+                start_time=dt.datetime.utcfromtimestamp(int(dbus_fact[1])),
+                end_time=dt.datetime.utcfromtimestamp(int(dbus_fact[2])) if dbus_fact[2] else None,
                 description=dbus_fact[3],
-                activity_id=dbus_fact[5],
+                activity_id=int(dbus_fact[5]),
                 category=dbus_fact[6],
                 tags=dbus_fact[7],
-                id=dbus_fact[0]
+                id=int(dbus_fact[0])
                 )
 
 


### PR DESCRIPTION
In the creation of a Fact() coming from dbus, explicitly convert dbus integer types to standard ints. This is an alternative work-around for #477. It should increase uniformity and help guard against other possible type issues for facts coming from dbus compared to facts created directly by hamster. 

I have tested this with python 3.7.3 and dbus 1.2.8 by running tests/stuff_tests.py and by creating tasks with hamster-cli and editing them with the GUI. 