### PR TITLE
Forbid unparseable facts - take2

### DIFF
--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -356,6 +356,11 @@ class CustomFactController(gobject.GObject):
             self.update_status(status="warning", markup=markup)
             return fact
 
+        roundtrip_fact = Fact.parse(fact.serialized())
+        if roundtrip_fact != fact:
+            self.update_status(status="wrong", markup="Fact could not be parsed back")
+            return None
+
         # nothing unusual
         self.update_status(status="looks good", markup="")
         return fact


### PR DESCRIPTION
Make the save button active only if the fact entered can be parsed (and thus edited) from the cmdline.
This hopefully answers https://github.com/projecthamster/hamster/pull/461#issuecomment-549302989 favorably, while waiting for #465.

[This is the last commit of #476, which will be closed]