### PR TITLE
Link from most recent database directory first

### DIFF
--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -115,11 +115,17 @@ class Storage(storage.Storage):
         # check if we have a database at all
         if not os.path.exists(db_path):
             # handle pre-existing hamster-applet database
-            old_db_path = os.path.join(xdg_data_home, 'hamster-applet', 'hamster.db')
-            if os.path.exists(old_db_path):
-                logger.warning("Linking {} with {}".format(old_db_path, db_path))
-                os.link(old_db_path, db_path)
-            else:
+            # try most recent directories first
+            # change from hamster-applet to hamster-time-tracker:
+            # 9f345e5e (2019-09-19)
+            old_dirs = ['hamster-time-tracker', 'hamster-applet']
+            for old_dir in old_dirs:
+                old_db_path = os.path.join(xdg_data_home, old_dir, 'hamster.db')
+                if os.path.exists(old_db_path):
+                    logger.warning("Linking {} with {}".format(old_db_path, db_path))
+                    os.link(old_db_path, db_path)
+                    break
+            if not os.path.exists(db_path):
                 # make a copy of the empty template hamster.db
                 try:
                     from hamster import defs


### PR DESCRIPTION
Otherwise it might pick an unused `hamster-applet/hamster.db` 
(for some reasons it was not hard linked on my system
*Edit: that was due to file synchronization by unison*)
instead of the more recent `hamster-time-tracker/hamster.db`.
The change to hamster-time-tracker has never been released, 
but it is few months old (9f345e5eac477bba5d4f3ea68d71aa21cc39e3b1), 
so it is nicer to early adopters to handle that correctly as well.

Check for hard links (the first numbers should be identical):
```bash
ls -il ~/.local/share/hamster*/hamster.db
1105569312 -rw-rw-r-- 3 ederag users 1589248  7 déc.  09:50 /home/ederag/.local/share/hamster-applet/hamster.db
1105569312 -rw-rw-r-- 3 ederag users 1589248  7 déc.  09:50 /home/ederag/.local/share/hamster-time-tracker/hamster.db
1105569312 -rw-rw-r-- 3 ederag users 1589248  7 déc.  09:50 /home/ederag/.local/share/hamster/hamster.db
```
Keeping old dirs may be useful to compare behaviors between versions.