### PR TITLE
restore AddFact compatibility

### DIFF
--- a/src/hamster-service
+++ b/src/hamster-service
@@ -135,7 +135,7 @@ class Storage(db.Storage, dbus.service.Object):
     @dbus.service.method("org.gnome.Hamster", in_signature='siib', out_signature='i')
     def AddFact(self, fact_str, start_time, end_time, temporary=False):
         fact = Fact.parse(fact_str)
-        fact.start_time = dt.datetime.utcfromtimestamp(start_time) if start_time else None
+        fact.start_time = dt.datetime.utcfromtimestamp(start_time) if start_time else stuff.hamster_now()
         fact.end_time = dt.datetime.utcfromtimestamp(end_time) if end_time else None
         
         return self.add_fact(fact) or 0


### PR DESCRIPTION
DBus compatibility was lost, as reported by @jmberg in the shell-extension:
https://github.com/projecthamster/hamster-shell-extension/pull/316#issuecomment-564145295

This is a blind tentative to fix it.
(shell extension does not work here, and an earlier attempt to install it in an ubuntu virtualbox failed)