### PR TITLE
Explicit schema_id in gio.Settings init

### DIFF
--- a/src/hamster/lib/configuration.py
+++ b/src/hamster/lib/configuration.py
@@ -200,7 +200,7 @@ class GSettingsStore(gobject.GObject, Singleton):
 
     def __init__(self):
         gobject.GObject.__init__(self)
-        self._settings = gio.Settings('org.gnome.Hamster')
+        self._settings = gio.Settings(schema_id='org.gnome.Hamster')
 
     def _key_changed(self, client, key, data=None):
         """


### PR DESCRIPTION
Fixed
```
> python3 tests/stuff_test.py 
/home/ederag/share/prog/python/hamster/src/hamster/lib/configuration.py:203: 
PyGIDeprecationWarning:
Using positional arguments with the GObject constructor has been deprecated. 
Please specify keyword(s) for "schema" or use a class specific constructor. 
See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self._settings = gio.Settings('org.gnome.Hamster')
```