### PR TITLE
check fact before inclusion

### DIFF
--- a/src/hamster-cli.py
+++ b/src/hamster-cli.py
@@ -149,6 +149,7 @@ class HamsterClient(object):
         fact = Fact.parse(" ".join(args), range_pos="tail")
         if fact.start_time is None:
             fact.start_time = stuff.hamster_now()
+        fact.check(default_day=stuff.hamster_today())
         self.storage.add_fact(fact)
 
     def stop(self, *args):

--- a/src/hamster-service.py
+++ b/src/hamster-service.py
@@ -17,10 +17,11 @@ from hamster.lib.dbus import (
     DBusMainLoop,
     dbus,
     fact_signature,
+    from_dbus_date,
     from_dbus_fact,
     to_dbus_fact
 )
-from hamster.lib.fact import Fact
+from hamster.lib.fact import Fact, FactError
 
 logger = default_logger(__file__)
 
@@ -171,6 +172,22 @@ class Storage(db.Storage, dbus.service.Object):
     def AddFactVerbatim(self, dbus_fact):
         fact = from_dbus_fact(dbus_fact)
         return self.add_fact(fact) or 0
+
+
+    @dbus.service.method("org.gnome.Hamster",
+                         in_signature="{}i".format(fact_signature),
+                         out_signature='bs')
+    def CheckFact(self, dbus_fact, dbus_default_day):
+        fact = from_dbus_fact(dbus_fact)
+        dd = from_dbus_date(dbus_default_day)
+        try:
+            self.check_fact(fact, default_day=dd)
+            success = True
+            message = ""
+        except FactError as error:
+            success = False
+            message = str(error)
+        return success, message
 
 
     @dbus.service.method("org.gnome.Hamster",

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -345,7 +345,7 @@ class CustomFactController(gobject.GObject):
                           fact.end_time or default_dt)
 
         try:
-            fact.check(default_day=self.date)
+            runtime.storage.check_fact(fact, default_day=self.date)
         except FactError as error:
             self.update_status(status="wrong", markup=str(error))
             return None

--- a/src/hamster/lib/dbus.py
+++ b/src/hamster/lib/dbus.py
@@ -8,6 +8,19 @@ from hamster.lib.fact import Fact
 
 """D-Bus communication utilities."""
 
+# dates
+
+def from_dbus_date(dbus_date):
+    """Convert D-Bus timestamp (seconds since epoch) to date."""
+    return dt.date.fromtimestamp(dbus_date) if dbus_date else None
+
+
+def to_dbus_date(date):
+    """Convert date to D-Bus timestamp (seconds since epoch)."""
+    return timegm(date.timetuple()) if date else 0
+
+
+# facts
 
 """
 dbus_fact signature (types matching the to_dbus_fact output)
@@ -51,5 +64,5 @@ def to_dbus_fact(fact):
             fact.activity_id or 0,
             fact.category or '',
             dbus.Array(fact.tags, signature = 's'),
-            timegm(fact.date.timetuple()),
+            to_dbus_date(fact.date),
             fact.delta.days * 24 * 60 * 60 + fact.delta.seconds)

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -75,42 +75,6 @@ class Fact(object):
     def category(self, value):
         self._category = value.strip() if value else ""
 
-    def check(self, default_day=None):
-        """Check Fact validity for inclusion in the storage."""
-        if self.start_time is None:
-            raise FactError("Missing start time")
-
-        if self.end_time and (self.delta < dt.timedelta(0)):
-            fixed_fact = Fact(start_time=self.start_time,
-                              end_time=self.end_time + dt.timedelta(days=1))
-            suggested_range_str = fixed_fact.serialized_range(default_day=default_day)
-            # work around cyclic imports
-            from hamster.lib.configuration import conf
-            raise FactError(dedent(
-                """\
-                Duration would be negative.
-                Working late ?
-                This happens when the activity crosses the
-                hamster day start time ({:%H:%M} from tracking settings).
-
-                Suggestion: move the end to the next day; the range would become:
-                {}
-                (in civil local time)
-                """.format(conf.day_start, suggested_range_str)
-                ))
-
-        if not self.activity:
-            raise FactError("Missing activity")
-
-        if ',' in self.category:
-            raise FactError(dedent(
-                """\
-                Forbidden comma in category: '{}'
-                Note: The description separator changed
-                      from single comma to double comma ',,' (cf. PR #482).
-                """.format(self.category)
-                ))
-
     def copy(self, **kwds):
         """Return an independent copy, with overrides as keyword arguments.
 

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -2,8 +2,10 @@ import logging
 logger = logging.getLogger(__name__)   # noqa: E402
 
 import calendar
+import datetime as dt
 
 from copy import deepcopy
+from textwrap import dedent
 
 from hamster.lib.parsing import TIME_FMT, DATETIME_FMT, parse_fact
 from hamster.lib.stuff import (
@@ -12,6 +14,9 @@ from hamster.lib.stuff import (
     hamster_now,
     hamster_today,
 )
+
+class FactError(Exception):
+    """Generic Fact error."""
 
 
 class Fact(object):
@@ -69,6 +74,42 @@ class Fact(object):
     @category.setter
     def category(self, value):
         self._category = value.strip() if value else ""
+
+    def check(self, default_day=None):
+        """Check Fact validity for inclusion in the storage."""
+        if self.start_time is None:
+            raise FactError("Missing start time")
+
+        if self.end_time and (self.delta < dt.timedelta(0)):
+            fixed_fact = Fact(start_time=self.start_time,
+                              end_time=self.end_time + dt.timedelta(days=1))
+            suggested_range_str = fixed_fact.serialized_range(default_day=default_day)
+            # work around cyclic imports
+            from hamster.lib.configuration import conf
+            raise FactError(dedent(
+                """\
+                Duration would be negative.
+                Working late ?
+                This happens when the activity crosses the
+                hamster day start time ({:%H:%M} from tracking settings).
+
+                Suggestion: move the end to the next day; the range would become:
+                {}
+                (in civil local time)
+                """.format(conf.day_start, suggested_range_str)
+                ))
+
+        if not self.activity:
+            raise FactError("Missing activity")
+
+        if ',' in self.category:
+            raise FactError(dedent(
+                """\
+                Forbidden comma in category: '{}'
+                Note: The description separator changed
+                      from single comma to double comma ',,' (cf. PR #482).
+                """.format(self.category)
+                ))
 
     def copy(self, **kwds):
         """Return an independent copy, with overrides as keyword arguments.

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -517,6 +517,7 @@ class Storage(storage.Storage):
                                 description=fact["description"],
                                 start_time=end_time,
                                 end_time=fact_end_time)
+                storage.Storage.check_fact(new_fact)
                 new_fact_id = self.__add_fact(new_fact)
 
                 # copy tags
@@ -553,8 +554,6 @@ class Storage(storage.Storage):
                        Other errors would also be handled through exceptions.
         """
         logger.info("adding fact {}".format(fact))
-
-        self.validate_fact(fact)  # sanity check
 
         start_time = fact.start_time
         end_time = fact.end_time

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -22,7 +22,7 @@ import logging
 logger = logging.getLogger(__name__)   # noqa: E402
 
 import datetime as dt
-from hamster.lib.fact import Fact
+from hamster.lib.fact import Fact, FactError
 from hamster.lib.stuff import hamster_now
 
 class Storage(object):
@@ -39,8 +39,46 @@ class Storage(object):
         self.facts_changed()
         self.activities_changed()
 
-
     # facts
+    def check_fact(self, fact, default_day=None):
+        """Check Fact validity for inclusion in the storage.
+
+        Raise FactError(message) on failure.
+        """
+        if fact.start_time is None:
+            raise FactError("Missing start time")
+
+        if fact.end_time and (fact.delta < dt.timedelta(0)):
+            fixed_fact = Fact(start_time=fact.start_time,
+                              end_time=fact.end_time + dt.timedelta(days=1))
+            suggested_range_str = fixed_fact.serialized_range(default_day=default_day)
+            # work around cyclic imports
+            from hamster.lib.configuration import conf
+            raise FactError(dedent(
+                """\
+                Duration would be negative.
+                Working late ?
+                This happens when the activity crosses the
+                hamster day start time ({:%H:%M} from tracking settings).
+
+                Suggestion: move the end to the next day; the range would become:
+                {}
+                (in civil local time)
+                """.format(conf.day_start, suggested_range_str)
+                ))
+
+        if not fact.activity:
+            raise FactError("Missing activity")
+
+        if ',' in fact.category:
+            raise FactError(dedent(
+                """\
+                Forbidden comma in category: '{}'
+                Note: The description separator changed
+                      from single comma to double comma ',,' (cf. PR #482).
+                """.format(fact.category)
+                ))
+
     def add_fact(self, fact, start_time=None, end_time=None, temporary=False):
         """Add fact.
 

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -40,7 +40,8 @@ class Storage(object):
         self.activities_changed()
 
     # facts
-    def check_fact(self, fact, default_day=None):
+    @classmethod
+    def check_fact(cls, fact, default_day=None):
         """Check Fact validity for inclusion in the storage.
 
         Raise FactError(message) on failure.
@@ -97,6 +98,8 @@ class Storage(object):
             fact.start_time = start_time
             fact.end_time = end_time
 
+        # better fail before opening the transaction
+        self.check_fact(fact)
         self.start_transaction()
         result = self.__add_fact(fact, temporary)
         self.end_transaction()
@@ -110,6 +113,8 @@ class Storage(object):
         return self.__get_fact(fact_id)
 
     def update_fact(self, fact_id, fact, start_time=None, end_time=None, temporary=False):
+        # better fail before opening the transaction
+        self.check_fact(fact)
         self.start_transaction()
         self.__remove_fact(fact_id)
         # to be removed once update facts use Fact directly.
@@ -123,11 +128,6 @@ class Storage(object):
         if result:
             self.facts_changed()
         return result
-
-    def validate_fact(self, fact):
-        """Check fact validity for inclusion into storage."""
-        assert fact.activity, "missing activity"
-        assert fact.start_time, "missing start_time"
 
     def stop_tracking(self, end_time):
         """Stops tracking the current activity"""


### PR DESCRIPTION
As promised in #482:
> **Breaking change**:
double comma `,,` is now always required to start a description.
Single comma does not work any longer for this purpose.
If a single comma happens to be used by mistake, 
the comma and the following text would end in the category.
So comma will be forbidden in the category,
to raise an error instead of merging a wrong fact in the database.
That will be the purpose of a forthcoming PR.

The same `Fact.check` is used from the command line and from the gui.
