### PR TITLE
Hamster datetime

### DIFF
--- a/src/hamster-cli.py
+++ b/src/hamster-cli.py
@@ -148,7 +148,7 @@ class HamsterClient(object):
         fact = Fact.parse(" ".join(args), range_pos="tail")
         if fact.start_time is None:
             fact.start_time = dt.datetime.now()
-        self.storage.check_fact(fact, default_day=dt.today())
+        self.storage.check_fact(fact, default_day=dt.hday.today())
         self.storage.add_fact(fact)
 
     def stop(self, *args):

--- a/src/hamster-cli.py
+++ b/src/hamster-cli.py
@@ -30,8 +30,8 @@ import datetime as dt
 from hamster import client, reports
 from hamster import logger as hamster_logger
 from hamster.lib import default_logger, stuff
+from hamster.lib import datetime as hdt
 from hamster.lib.fact import Fact
-from hamster.lib.parsing import parse_datetime_range
 
 
 logger = default_logger(__file__)
@@ -162,7 +162,7 @@ class HamsterClient(object):
         export_format, start_time, end_time = "html", None, None
         if args:
             export_format = args[0]
-        start_time, end_time, _ = parse_datetime_range(" ".join(args[1:]))
+        start_time, end_time, _ = hdt.Range.parse(" ".join(args[1:]))
 
         start_time = start_time or dt.datetime.combine(dt.date.today(), dt.time())
         end_time = end_time or start_time.replace(hour=23, minute=59, second=59)
@@ -199,7 +199,7 @@ class HamsterClient(object):
 
     def list(self, *times):
         """list facts within a date range"""
-        start_time, end_time, _ = parse_datetime_range(" ".join(times or []))
+        start_time, end_time, _ = hdt.Range.parse(" ".join(times or []))
 
         start_time = start_time or dt.datetime.combine(dt.date.today(), dt.time())
         end_time = end_time or start_time.replace(hour=23, minute=59, second=59)
@@ -223,7 +223,7 @@ class HamsterClient(object):
         if args:
             search = args[0]
 
-        start_time, end_time, _ = parse_datetime_range(" ".join(args[1:]))
+        start_time, end_time, _ = hdt.Range.parse(" ".join(args[1:]))
 
         start_time = start_time or dt.datetime.combine(dt.date.today(), dt.time())
         end_time = end_time or start_time.replace(hour=23, minute=59, second=59)

--- a/src/hamster-cli.py
+++ b/src/hamster-cli.py
@@ -162,7 +162,7 @@ class HamsterClient(object):
         export_format, start_time, end_time = "html", None, None
         if args:
             export_format = args[0]
-        start_time, end_time, _ = hdt.Range.parse(" ".join(args[1:]))
+        (start_time, end_time), __ = hdt.Range.parse(" ".join(args[1:]))
 
         start_time = start_time or dt.datetime.combine(dt.date.today(), dt.time())
         end_time = end_time or start_time.replace(hour=23, minute=59, second=59)
@@ -199,7 +199,7 @@ class HamsterClient(object):
 
     def list(self, *times):
         """list facts within a date range"""
-        start_time, end_time, _ = hdt.Range.parse(" ".join(times or []))
+        (start_time, end_time), __ = hdt.Range.parse(" ".join(times or []))
 
         start_time = start_time or dt.datetime.combine(dt.date.today(), dt.time())
         end_time = end_time or start_time.replace(hour=23, minute=59, second=59)
@@ -223,7 +223,7 @@ class HamsterClient(object):
         if args:
             search = args[0]
 
-        start_time, end_time, _ = hdt.Range.parse(" ".join(args[1:]))
+        (start_time, end_time), __ = hdt.Range.parse(" ".join(args[1:]))
 
         start_time = start_time or dt.datetime.combine(dt.date.today(), dt.time())
         end_time = end_time or start_time.replace(hour=23, minute=59, second=59)

--- a/src/hamster-cli.py
+++ b/src/hamster-cli.py
@@ -63,7 +63,7 @@ def fact_dict(fact_data, with_date):
     if fact_data.end_time:
         fact['end'] = fact_data.end_time.strftime(fmt)
     else:
-        end_date = stuff.hamster_now()
+        end_date = dt.datetime.now()
         fact['end'] = ''
 
     fact['duration'] = stuff.format_duration(fact_data.delta)
@@ -147,7 +147,7 @@ class HamsterClient(object):
 
         fact = Fact.parse(" ".join(args), range_pos="tail")
         if fact.start_time is None:
-            fact.start_time = stuff.hamster_now()
+            fact.start_time = dt.datetime.now()
         self.storage.check_fact(fact, default_day=stuff.hamster_today())
         self.storage.add_fact(fact)
 

--- a/src/hamster-cli.py
+++ b/src/hamster-cli.py
@@ -148,7 +148,7 @@ class HamsterClient(object):
         fact = Fact.parse(" ".join(args), range_pos="tail")
         if fact.start_time is None:
             fact.start_time = dt.datetime.now()
-        self.storage.check_fact(fact, default_day=stuff.hamster_today())
+        self.storage.check_fact(fact, default_day=dt.today())
         self.storage.add_fact(fact)
 
     def stop(self, *args):

--- a/src/hamster-cli.py
+++ b/src/hamster-cli.py
@@ -25,12 +25,11 @@
 import sys, os
 import argparse
 import re
-import datetime as dt
 
 from hamster import client, reports
 from hamster import logger as hamster_logger
 from hamster.lib import default_logger, stuff
-from hamster.lib import datetime as hdt
+from hamster.lib import datetime as dt
 from hamster.lib.fact import Fact
 
 
@@ -162,7 +161,7 @@ class HamsterClient(object):
         export_format, start_time, end_time = "html", None, None
         if args:
             export_format = args[0]
-        (start_time, end_time), __ = hdt.Range.parse(" ".join(args[1:]))
+        (start_time, end_time), __ = dt.Range.parse(" ".join(args[1:]))
 
         start_time = start_time or dt.datetime.combine(dt.date.today(), dt.time())
         end_time = end_time or start_time.replace(hour=23, minute=59, second=59)
@@ -199,7 +198,7 @@ class HamsterClient(object):
 
     def list(self, *times):
         """list facts within a date range"""
-        (start_time, end_time), __ = hdt.Range.parse(" ".join(times or []))
+        (start_time, end_time), __ = dt.Range.parse(" ".join(times or []))
 
         start_time = start_time or dt.datetime.combine(dt.date.today(), dt.time())
         end_time = end_time or start_time.replace(hour=23, minute=59, second=59)
@@ -223,7 +222,7 @@ class HamsterClient(object):
         if args:
             search = args[0]
 
-        (start_time, end_time), __ = hdt.Range.parse(" ".join(args[1:]))
+        (start_time, end_time), __ = dt.Range.parse(" ".join(args[1:]))
 
         start_time = start_time or dt.datetime.combine(dt.date.today(), dt.time())
         end_time = end_time or start_time.replace(hour=23, minute=59, second=59)

--- a/src/hamster-cli.py
+++ b/src/hamster-cli.py
@@ -66,7 +66,7 @@ def fact_dict(fact_data, with_date):
         end_date = dt.datetime.now()
         fact['end'] = ''
 
-    fact['duration'] = stuff.format_duration(fact_data.delta)
+    fact['duration'] = fact_data.delta.format()
 
     fact['activity'] = fact_data.activity
     fact['category'] = fact_data.category
@@ -210,7 +210,7 @@ class HamsterClient(object):
         facts = self.storage.get_todays_facts()
         if facts and not facts[-1].end_time:
             print("{} {}".format(str(facts[-1]).strip(),
-                                 stuff.format_duration(facts[-1].delta, human=False)))
+                                 facts[-1].delta.format(fmt="HH:MM")))
         else:
             print((_("No activity")))
 
@@ -286,12 +286,12 @@ class HamsterClient(object):
         cats = []
         total_duration = dt.timedelta()
         for cat, duration in sorted(by_cat.items(), key=lambda x: x[1], reverse=True):
-            cats.append("{}: {}".format(cat, stuff.format_duration(duration)))
+            cats.append("{}: {}".format(cat, duration.format()))
             total_duration += duration
 
         for line in word_wrap(", ".join(cats), 80):
             print(line)
-        print("Total: ", stuff.format_duration(total_duration))
+        print("Total: ", total_duration.format())
 
         print()
 

--- a/src/hamster-service.py
+++ b/src/hamster-service.py
@@ -3,8 +3,6 @@
 
 import logging
 from gi.repository import GLib as glib
-
-import datetime as dt
 from gi.repository import Gio as gio
 
 from hamster import logger as hamster_logger
@@ -12,6 +10,7 @@ from hamster.lib import i18n
 i18n.setup_i18n()
 
 from hamster.storage import db
+from hamster.lib import datetime as dt
 from hamster.lib import default_logger, stuff
 from hamster.lib.dbus import (
     DBusMainLoop,

--- a/src/hamster-service.py
+++ b/src/hamster-service.py
@@ -11,7 +11,7 @@ i18n.setup_i18n()
 
 from hamster.storage import db
 from hamster.lib import datetime as dt
-from hamster.lib import default_logger, stuff
+from hamster.lib import default_logger
 from hamster.lib.dbus import (
     DBusMainLoop,
     dbus,
@@ -138,7 +138,7 @@ class Storage(db.Storage, dbus.service.Object):
             start_time (int): Start datetime timestamp.
                               For backward compatibility with the
                               gnome shell extension,
-                              0 is special and means hamster_now().
+                              0 is special and means dt.datetime.now().
                               Otherwise, overrides the parsed value.
                               -1 means None.
             end_time (int): Start datetime timestamp.
@@ -155,7 +155,7 @@ class Storage(db.Storage, dbus.service.Object):
         if start_time == -1:
             fact.start_time = None
         elif start_time == 0:
-            fact.start_time = stuff.hamster_now()
+            fact.start_time = dt.datetime.now()
         else:
             fact.start_time = dt.datetime.utcfromtimestamp(start_time)
 

--- a/src/hamster/__init__.py
+++ b/src/hamster/__init__.py
@@ -1,4 +1,8 @@
+import gi
+
 from hamster.lib import default_logger
 
 
 logger = default_logger(__name__)
+gi.require_version('Gtk', '3.0')
+gi.require_version('PangoCairo', '1.0')

--- a/src/hamster/__init__.py
+++ b/src/hamster/__init__.py
@@ -1,8 +1,14 @@
 import gi
+gi.require_version('Gtk', '3.0')  # noqa: E402
+gi.require_version('PangoCairo', '1.0')  # noqa: E402
+# for some reason performance is improved by importing Gtk early
+from gi.repository import Gtk as gtk
 
 from hamster.lib import default_logger
 
 
 logger = default_logger(__name__)
-gi.require_version('Gtk', '3.0')
-gi.require_version('PangoCairo', '1.0')
+
+# cleanup namespace
+del default_logger
+del gtk  # performance is retained

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -32,7 +32,7 @@ from hamster.lib.dbus import (
     to_dbus_fact,
     )
 from hamster.lib.fact import Fact, FactError
-from hamster.lib.stuff import hamster_now
+from hamster.lib import datetime as dt
 
 
 class Storage(gobject.GObject):
@@ -179,7 +179,7 @@ class Storage(gobject.GObject):
 
         if not fact.start_time:
             logger.info("Adding fact without any start_time is deprecated")
-            fact.start_time = hamster_now()
+            fact.start_time = dt.datetime.now()
 
         dbus_fact = to_dbus_fact(fact)
         new_id = self.conn.AddFactVerbatim(dbus_fact)
@@ -189,7 +189,7 @@ class Storage(gobject.GObject):
     def stop_tracking(self, end_time = None):
         """Stop tracking current activity. end_time can be passed in if the
         activity should have other end time than the current moment"""
-        end_time = timegm((end_time or hamster_now()).timetuple())
+        end_time = timegm((end_time or dt.datetime.now()).timetuple())
         return self.conn.StopTracking(end_time)
 
     def remove_fact(self, fact_id):

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -290,7 +290,7 @@ class CustomFactController(gobject.GObject):
         with self.cmdline.handler_block(self.cmdline.checker):
             self.cmdline.set_text(label)
             if select:
-                time_str = self.cmdline_fact.serialized_range(default_day=self.date)
+                time_str = self.cmdline_fact.range.format(default_day=self.date)
                 self.cmdline.select_region(0, len(time_str))
 
     def update_fields(self):

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -30,7 +30,7 @@ from hamster import widgets
 from hamster.lib import datetime as dt
 from hamster.lib.configuration import runtime, conf, load_ui_file
 from hamster.lib.fact import Fact, FactError
-from hamster.lib.stuff import hamsterday_time_to_datetime, escape_pango
+from hamster.lib.stuff import escape_pango
 
 
 
@@ -269,8 +269,7 @@ class CustomFactController(gobject.GObject):
                                                          new_time)
                 else:
                     # date not specified; result must fall in current hamster_day
-                    new_start_time = hamsterday_time_to_datetime(dt.today(),
-                                                                 new_time)
+                    new_start_time = dt.datetime.from_day_time(dt.today(), new_time)
             else:
                 new_start_time = None
             self.fact.start_time = new_start_time

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -30,8 +30,7 @@ from hamster import widgets
 from hamster.lib import datetime as dt
 from hamster.lib.configuration import runtime, conf, load_ui_file
 from hamster.lib.fact import Fact, FactError
-from hamster.lib.stuff import (
-    hamsterday_time_to_datetime, hamster_today, escape_pango)
+from hamster.lib.stuff import hamsterday_time_to_datetime, escape_pango
 
 
 
@@ -250,7 +249,7 @@ class CustomFactController(gobject.GObject):
                     # preserve fact duration
                     self.fact.end_time += delta
                     self.end_date.date = self.fact.end_time
-            self.date = self.fact.date or hamster_today()
+            self.date = self.fact.date or dt.today()
             self.validate_fields()
             self.update_cmdline()
 
@@ -270,7 +269,7 @@ class CustomFactController(gobject.GObject):
                                                          new_time)
                 else:
                     # date not specified; result must fall in current hamster_day
-                    new_start_time = hamsterday_time_to_datetime(hamster_today(),
+                    new_start_time = hamsterday_time_to_datetime(dt.today(),
                                                                  new_time)
             else:
                 new_start_time = None

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -22,12 +22,12 @@ from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
 from textwrap import dedent
 import time
-import datetime as dt
 
 """ TODO: hook into notifications and refresh our days if some evil neighbour
           edit fact window has dared to edit facts
 """
 from hamster import widgets
+from hamster.lib import datetime as dt
 from hamster.lib.configuration import runtime, conf, load_ui_file
 from hamster.lib.fact import Fact, FactError
 from hamster.lib.stuff import (

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -31,7 +31,7 @@ from hamster.lib import datetime as dt
 from hamster.lib.configuration import runtime, conf, load_ui_file
 from hamster.lib.fact import Fact, FactError
 from hamster.lib.stuff import (
-    hamsterday_time_to_datetime, hamster_today, hamster_now, escape_pango)
+    hamsterday_time_to_datetime, hamster_today, escape_pango)
 
 
 
@@ -96,10 +96,10 @@ class CustomFactController(gobject.GObject):
             self.get_widget("delete_button").set_sensitive(False)
             if base_fact:
                 # start a clone now.
-                self.fact = base_fact.copy(start_time=hamster_now(),
+                self.fact = base_fact.copy(start_time=dt.datetime.now(),
                                            end_time=None)
             else:
-                self.fact = Fact(start_time=hamster_now())
+                self.fact = Fact(start_time=dt.datetime.now())
 
         original_fact = self.fact
         self.date = self.fact.date
@@ -192,7 +192,7 @@ class CustomFactController(gobject.GObject):
             # copy the entered fact before any modification
             self.cmdline_fact = fact.copy()
             if fact.start_time is None:
-                fact.start_time = hamster_now()
+                fact.start_time = dt.datetime.now()
             if fact.description == previous_cmdline_fact.description:
                 # no change to description here, keep the main one
                 fact.description = self.fact.description
@@ -333,7 +333,7 @@ class CustomFactController(gobject.GObject):
         """
         fact = self.fact
 
-        now = hamster_now()
+        now = dt.datetime.now()
         self.get_widget("button-next-day").set_sensitive(self.date < now.date())
 
         if self.date == now.date():

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -249,7 +249,7 @@ class CustomFactController(gobject.GObject):
                     # preserve fact duration
                     self.fact.end_time += delta
                     self.end_date.date = self.fact.end_time
-            self.date = self.fact.date or dt.today()
+            self.date = self.fact.date or dt.hday.today()
             self.validate_fields()
             self.update_cmdline()
 
@@ -269,7 +269,7 @@ class CustomFactController(gobject.GObject):
                                                          new_time)
                 else:
                     # date not specified; result must fall in current hamster_day
-                    new_start_time = dt.datetime.from_day_time(dt.today(), new_time)
+                    new_start_time = dt.datetime.from_day_time(dt.hday.today(), new_time)
             else:
                 new_start_time = None
             self.fact.start_time = new_start_time

--- a/src/hamster/lib/charting.py
+++ b/src/hamster/lib/charting.py
@@ -20,9 +20,10 @@
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 from gi.repository import Pango as pango
-import datetime as dt
+
 import time
 from hamster.lib import graphics, stuff
+from hamster.lib import datetime as dt
 import locale
 
 class Bar(graphics.Sprite):

--- a/src/hamster/lib/configuration.py
+++ b/src/hamster/lib/configuration.py
@@ -27,12 +27,13 @@ logger = logging.getLogger(__name__)   # noqa: E402
 import os
 from hamster.client import Storage
 from xdg.BaseDirectory import xdg_data_home
-import datetime as dt
 
 from gi.repository import Gio as gio
 from gi.repository import GLib as glib
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
+
+from hamster.lib import datetime as dt
 
 
 class Controller(gobject.GObject):

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -17,8 +17,6 @@ from collections import namedtuple
 from textwrap import dedent
 from functools import lru_cache
 
-# to be replaced soon
-from hamster.lib.stuff import hamsterday_end
 
 DATE_FMT = "%Y-%m-%d"  # ISO format
 TIME_FMT = "%H:%M"
@@ -83,6 +81,11 @@ class day(date):
 
     def __new__(cls, year, month, day):
         return date.__new__(cls, year, month, day)
+
+    @property
+    def end(self) -> datetime:
+        """Day end."""
+        return datetime.from_day_time(self + timedelta(days=1), self.start_time())
 
     @property
     def start(self) -> datetime:
@@ -421,10 +424,10 @@ class Range(namedtuple('Range', 'start, end')):
                 start = ref + delta1
 
         if m.group('lastday'):
-            lastday = date.parse(m.group('lastday'))
-            end = hamsterday_end(lastday)
+            lastday = day.parse(m.group('lastday'))
+            end = lastday.end
         elif firstday:
-            end = hamsterday_end(firstday)
+            end = firstday.end
         else:
             end =  datetime._extract_datetime(m, d="date2", h="hour2", m="minute2", r="relative2",
                                                   default_day=get_day(start))

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -523,6 +523,34 @@ class timedelta(pdt.timedelta):
                              seconds=self.seconds,
                              microseconds=self.microseconds)
 
+    def format(self, fmt="human"):
+        """Return a string representation, according to the format string fmt."""
+        allowed = ("human", "HH:MM")
+
+        total_s = self.total_seconds()
+        if total_s < 0:
+            # return a warning
+            return "NEGATIVE"
+
+        hours = int(total_s // 3600)
+        minutes = int((total_s - 3600 * hours) // 60)
+
+        if fmt == "human":
+            if minutes % 60 == 0:
+                # duration in round hours
+                return "{}h".format(hours)
+            elif hours == 0:
+                # duration less than one hour
+                return "{}min".format(minutes)
+            else:
+                # x hours, y minutes
+                return "{}h {}min".format(hours, minutes)
+        elif fmt == "HH:MM":
+            return "{:02d}:{:02d}".format(hours, minutes)
+        else:
+            raise NotImplementedError(
+                "'{}' not in allowed formats: {}".format(fmt, allowed))
+
 
 def get_day(civil_date_time):
     """Return the hamster day corresponding to a given civil datetime.

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -15,6 +15,7 @@ import re
 
 from collections import namedtuple
 from textwrap import dedent
+from functools import lru_cache
 
 # to be replaced soon
 from hamster.lib.stuff import datetime_to_hamsterday, hamster_now, hamster_today, hamsterday_end, hamsterday_start, hamsterday_time_to_datetime
@@ -209,6 +210,7 @@ class datetime(dt.datetime):
         return cls._extract_datetime(m, default_day=default_day) if m else None
 
     @classmethod
+    @lru_cache()
     def pattern(cls, n=None):
         """Return a datetime pattern with all group names.
 
@@ -348,6 +350,7 @@ class Range(namedtuple('Range', 'start, end')):
         return Range(start, end), rest
 
     @classmethod
+    @lru_cache()
     def pattern(cls):
         return dedent(r"""
             (                    # start

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -101,6 +101,11 @@ class hday(date):
         from hamster.lib.configuration import conf
         return conf.day_start
 
+    @classmethod
+    def today(cls):
+        """Return the current hamster day."""
+        return datetime.now().hday()
+
 
 class time(pdt.time):
     """Hamster time.
@@ -410,7 +415,7 @@ class Range(namedtuple('Range', 'start, end')):
             ref = datetime.now()
 
         if default_day is None:
-            default_day = today()
+            default_day = hday.today()
 
         assert position in ("exact", "head", "tail"), "position unknown: '{}'".format(position)
         if position == "exact":
@@ -574,8 +579,3 @@ class timedelta(pdt.timedelta):
         else:
             raise NotImplementedError(
                 "'{}' not in allowed formats: {}".format(fmt, allowed))
-
-
-def today():
-    """Return the current day."""
-    return datetime.now().hday()

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -389,6 +389,27 @@ class Range():
     def __iter__(self):
         return (self.start, self.end).__iter__()
 
+    def format(self, default_day=None):
+        """Return a string representing the time range.
+
+        Start date is shown only if start does not belong to default_day.
+        End date is shown only if end does not belong to
+        the same hamster day as start.
+        """
+        time_str = ""
+        if self.start:
+            if self.start.hday() != default_day:
+                time_str += self.start.strftime(DATETIME_FMT)
+            else:
+                time_str += self.start.strftime(TIME_FMT)
+        if self.end:
+            if self.end.hday() != self.start.hday():
+                end_time_str = self.end.strftime(DATETIME_FMT)
+            else:
+                end_time_str = self.end.strftime(TIME_FMT)
+            time_str = "{} - {}".format(time_str, end_time_str)
+        return time_str
+
     @classmethod
     def parse(cls, text,
               position="exact", separator="\s+", default_day=None, ref="now"):

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -375,11 +375,19 @@ class datetime(pdt.datetime):
 datetime.re = re.compile(datetime.pattern(), flags=re.VERBOSE)
 
 
-class Range(namedtuple('Range', 'start, end')):
+class Range():
     """Time span between two datetimes."""
 
     # slight memory optimization; no further attributes besides start or end.
-    __slots__ = ()
+    __slots__ = ('start', 'end')
+
+    def __init__(self, start=None, end=None):
+        self.start = start
+        self.end = end
+
+    # allow start, end = range
+    def __iter__(self):
+        return (self.start, self.end).__iter__()
 
     @classmethod
     def parse(cls, text,

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -52,6 +52,75 @@ class date(dt.date):
                    )
 
 
+class time(dt.time):
+    """Hamster time.
+
+    Should replace the python datetime.time in any customer code.
+    Specificities:
+    - rounded to minutes
+    - conversion to and from string facilities
+    """
+
+    FMT = "%H:%M"  # e.g. 13:30
+    # match time, such as "01:32", "13.56" or "0116"
+    pattern = r"""
+        (?P<hour>                         # hour
+         [0-9](?=[,\.:])                  # positive lookahead:
+                                          # allow a single digit only if
+                                          # followed by a colon, dot or comma
+         | [0-1][0-9]                     # 00 to 19
+         | [2][0-3]                       # 20 to 23
+        )
+        [,\.:]?                           # Separator can be colon,
+                                          # dot, comma, or nothing.
+        (?P<minute>[0-5][0-9])            # minute (2 digits, between 00 and 59)
+        (?!\d?-\d{2}-\d{2})               # Negative lookahead:
+                                          # avoid matching date by inadvertance.
+                                          # For instance 2019-12-05
+                                          # might be caught as 2:01.
+                                          # Requiring space or - would not work:
+                                          # 2019-2025 is the 20:19-20:25 range.
+    """
+    re = re.compile(pattern, flags=re.VERBOSE)
+
+    def __new__(cls,
+                hour=0, minute=0,
+                second=0, microsecond=0,
+                tzinfo=None, fold=0):
+            # round down to zero seconds and microseconds
+            return dt.time.__new__(cls,
+                                   hour=hour, minute=minute,
+                                   second=0, microsecond=0,
+                                   tzinfo=None, fold=fold)
+
+    @classmethod
+    def _extract_time(cls, match, h="hour", m="minute"):
+        """Extract time from a time.re match.
+
+        Custom group names allow to use the same method
+        for two times in the same regexp (e.g. for range parsing)
+
+        h (str): name of the group containing the hour
+        m (str): name of the group containing the minute
+
+        seealso: time.parse
+        """
+        h_str = match.group(h)
+        m_str = match.group(m)
+        if h_str and m_str:
+            hour = int(h_str)
+            minute = int(m_str)
+            return cls(hour, minute)
+        else:
+            return None
+
+    @classmethod
+    def parse(cls, s):
+        """Parse time from string."""
+        m = cls.re.search(s)
+        return cls._extract_time(m) if m else None
+
+
 class datetime(dt.datetime):
     """Hamster datetime.
 

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -28,7 +28,7 @@ class date(dt.date):
 
     Should replace the python datetime.date in any customer code.
 
-    Same a python date, with the addition of parse methods.
+    Same as python date, with the addition of parse methods.
     """
 
     FMT = "%Y-%m-%d"  # ISO format
@@ -119,7 +119,7 @@ class time(dt.time):
     def pattern(cls):
         """Return a time pattern with all group names."""
 
-        # remove the indentation => easier debugging.
+        # remove the indentation for easier debugging.
         return dedent(r"""
             (?P<hour>                         # hour
              [0-9](?=[,\.:])                  # positive lookahead:
@@ -211,7 +211,7 @@ class datetime(dt.datetime):
     def pattern(cls, n=None):
         """Return a datetime pattern with all group names.
 
-        If n is given, all groups are suffixed with n.
+        If n is given, all groups are suffixed with str(n).
         """
 
         # remove the indentation => easier debugging.

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+"""Python datetime.datetime replacement, tuned for hamster use."""
+
+
+import logging
+logger = logging.getLogger(__name__)   # noqa: E402
+
+import datetime as dt
+
+
+DATE_FMT = "%Y-%m-%d"  # ISO format
+TIME_FMT = "%H:%M"
+DATETIME_FMT = "{} {}".format(DATE_FMT, TIME_FMT)
+
+
+class datetime(dt.datetime):
+    """Hamster datetime.
+
+    Should replace the python datetime.datetime in any customer code.
+    Specificities:
+    - rounded to minutes
+    - conversion to and from string facilities
+    """
+    def __new__(cls, year, month, day,
+                hour=0, minute=0,
+                second=0, microsecond=0,
+                tzinfo=None, fold=0):
+            # round down to zero seconds and microseconds
+            return dt.datetime.__new__(cls, year, month, day,
+                                       hour=hour, minute=minute,
+                                       second=0, microsecond=0,
+                                       tzinfo=None, fold=fold)
+
+    def __str__(self):
+        if self.tzinfo:
+            raise NotImplementedError("Stay tuned...")
+        else:
+            return self.strftime(DATETIME_FMT)

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -18,7 +18,7 @@ from textwrap import dedent
 from functools import lru_cache
 
 # to be replaced soon
-from hamster.lib.stuff import hamster_now, hamster_today, hamsterday_end, hamsterday_start, hamsterday_time_to_datetime
+from hamster.lib.stuff import hamster_today, hamsterday_end, hamsterday_start, hamsterday_time_to_datetime
 
 DATE_FMT = "%Y-%m-%d"  # ISO format
 TIME_FMT = "%H:%M"
@@ -232,6 +232,11 @@ class datetime(pdt.datetime):
                    t.tzinfo, fold=t.fold)
 
     @classmethod
+    def now(cls):
+        """Current datetime."""
+        return cls.from_pdt(pdt.datetime.now())
+
+    @classmethod
     def parse(cls, s, default_day=None):
         """Parse a datetime from text.
 
@@ -318,7 +323,7 @@ class Range(namedtuple('Range', 'start, end')):
                            (e.g. -15: quarter hour before ref).
                            For testing purposes only
                            (note: this will be removed later on,
-                            and replaced with hamster_now mocking in pytest).
+                            and replaced with datetime.now mocking in pytest).
                            For users, it should be "now".
         Return:
             (range, rest)
@@ -327,7 +332,7 @@ class Range(namedtuple('Range', 'start, end')):
         """
 
         if ref == "now":
-            ref = hamster_now()
+            ref = datetime.now()
 
         if default_day is None:
             default_day = hamster_today()

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -67,25 +67,6 @@ class time(dt.time):
 
     FMT = "%H:%M"  # e.g. 13:30
     # match time, such as "01:32", "13.56" or "0116"
-    pattern = r"""
-        (?P<hour>                         # hour
-         [0-9](?=[,\.:])                  # positive lookahead:
-                                          # allow a single digit only if
-                                          # followed by a colon, dot or comma
-         | [0-1][0-9]                     # 00 to 19
-         | [2][0-3]                       # 20 to 23
-        )
-        [,\.:]?                           # Separator can be colon,
-                                          # dot, comma, or nothing.
-        (?P<minute>[0-5][0-9])            # minute (2 digits, between 00 and 59)
-        (?!\d?-\d{2}-\d{2})               # Negative lookahead:
-                                          # avoid matching date by inadvertance.
-                                          # For instance 2019-12-05
-                                          # might be caught as 2:01.
-                                          # Requiring space or - would not work:
-                                          # 2019-2025 is the 20:19-20:25 range.
-    """
-    re = re.compile(pattern, flags=re.VERBOSE)
 
     def __new__(cls,
                 hour=0, minute=0,
@@ -123,6 +104,37 @@ class time(dt.time):
         """Parse time from string."""
         m = cls.re.search(s)
         return cls._extract_time(m) if m else None
+
+    # For datetime that must be a method.
+    # Same here for consistency.
+    @classmethod
+    def pattern(cls):
+        """Return a time pattern with all group names."""
+
+        # remove the indentation => easier debugging.
+        return dedent(r"""
+            (?P<hour>                         # hour
+             [0-9](?=[,\.:])                  # positive lookahead:
+                                              # allow a single digit only if
+                                              # followed by a colon, dot or comma
+             | [0-1][0-9]                     # 00 to 19
+             | [2][0-3]                       # 20 to 23
+            )
+            [,\.:]?                           # Separator can be colon,
+                                              # dot, comma, or nothing.
+            (?P<minute>[0-5][0-9])            # minute (2 digits, between 00 and 59)
+            (?!\d?-\d{2}-\d{2})               # Negative lookahead:
+                                              # avoid matching date by inadvertance.
+                                              # For instance 2019-12-05
+                                              # might be caught as 2:01.
+                                              # Requiring space or - would not work:
+                                              # 2019-2025 is the 20:19-20:25 range.
+            """)
+
+
+# For datetime that will need to be outside the class.
+# Same here for consistency
+time.re = re.compile(time.pattern(), flags=re.VERBOSE)
 
 
 class datetime(dt.datetime):
@@ -206,7 +218,7 @@ class datetime(dt.datetime):
                 \s?                           # maybe one space
                 {}                            # time
             )
-            """).format(date.detailed_pattern, time.pattern)
+            """).format(date.detailed_pattern, time.pattern())
         if n is None:
             return base_pattern
         else:

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -32,16 +32,6 @@ class date(dt.date):
     """
 
     FMT = "%Y-%m-%d"  # ISO format
-    basic_pattern = r"""\d{4}-\d{2}-\d{2}"""
-    basic_re = re.compile(basic_pattern, flags=re.VERBOSE)
-    detailed_pattern = r"""
-        (?P<year>\d{4})        # 4 digits
-        -                      # dash
-        (?P<month>\d{2})       # 2 digits
-        -                      # dash
-        (?P<day>\d{2})         # 2 digits
-    """
-    detailed_re = re.compile(detailed_pattern, flags=re.VERBOSE)
 
     def __new__(cls, year, month, day):
         return dt.date.__new__(cls, year, month, day)
@@ -49,11 +39,29 @@ class date(dt.date):
     @classmethod
     def parse(cls, s):
         """Return date from string."""
-        m = cls.detailed_re.search(s)
+        m = cls.re.search(s)
         return cls(year=int(m.group('year')),
                    month=int(m.group('month')),
                    day=int(m.group('day'))
                    )
+
+    @classmethod
+    def pattern(cls, detailed=True):
+        if detailed:
+            return dedent(r"""
+                (?P<year>\d{4})        # 4 digits
+                -                      # dash
+                (?P<month>\d{2})       # 2 digits
+                -                      # dash
+                (?P<day>\d{2})         # 2 digits
+                """)
+        else:
+            return r"""\d{4}-\d{2}-\d{2}"""
+
+
+# For datetime that will need to be outside the class.
+# Same here for consistency
+date.re = re.compile(date.pattern(), flags=re.VERBOSE)
 
 
 class time(dt.time):
@@ -218,7 +226,7 @@ class datetime(dt.datetime):
                 \s?                           # maybe one space
                 {}                            # time
             )
-            """).format(date.detailed_pattern, time.pattern())
+            """).format(date.pattern(), time.pattern())
         if n is None:
             return base_pattern
         else:

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -16,7 +16,7 @@ import re
 from textwrap import dedent
 
 # to be replaced soon
-from hamster.lib.stuff import hamsterday_time_to_datetime
+from hamster.lib.stuff import datetime_to_hamsterday, hamster_now, hamster_today, hamsterday_end, hamsterday_start, hamsterday_time_to_datetime
 
 DATE_FMT = "%Y-%m-%d"  # ISO format
 TIME_FMT = "%H:%M"
@@ -248,6 +248,128 @@ class datetime(dt.datetime):
 # outside class; need the class to be defined first
 datetime.re = re.compile(datetime.pattern(), flags=re.VERBOSE)
 
+
+class Range():
+    def __init__(self, start, end=None):
+        self.start = start
+        self.end = end
+
+    # I know, that should return a Range. Let's finish the move first.
+    @classmethod
+    def parse(cls, text,
+              position="exact", separator="\s+", default_day=None, ref="now"):
+        """Parse a start-end range from text.
+
+        position (str): "exact" to match exactly the full text
+                        "head" to search only at the beginning of text, and
+                        "tail" to search only at the end.
+
+        separator (str): regexp pattern (e.g. '\s+') meant to separate the datetime
+                         from the rest. Discarded for "exact" position.
+
+        default_day (dt.date): If start is given without any date (e.g. just hh:mm),
+                               put the corresponding datetime in default_day.
+                               Defaults to hamster_today.
+                               Note: the default end day is always the start day, so
+                                     "2019-11-27 23:50 - 00:20" lasts 30 minutes.
+
+        ref (dt.datetime): reference for relative times
+                           (e.g. -15: quarter hour before ref).
+                           For testing purposes only
+                           (note: this will be removed later on,
+                            and replaced with hamster_now mocking in pytest).
+                           For users, it should be "now".
+        Return:
+            (start, end, rest)
+            """
+
+        if ref == "now":
+            ref = hamster_now()
+
+        if default_day is None:
+            default_day = hamster_today()
+
+        assert position in ("exact", "head", "tail"), "position unknown: '{}'".format(position)
+        if position == "exact":
+            p = "^{}$".format(cls.pattern())
+        elif position == "head":
+            # require at least a space after, to avoid matching 10.00@cat
+            # .*? so rest is as little as possible
+            p = "^{}{}(?P<rest>.*?)$".format(cls.pattern(), separator)
+        elif position == "tail":
+            # require at least a space after, to avoid matching #10.00
+            # .*? so rest is as little as possible
+            p = "^(?P<rest>.*?){}{}$".format(separator, cls.pattern())
+        # no need to compile, recent patterns are cached by re
+        m = re.search(p, text, flags=re.VERBOSE)
+
+        if not m:
+            return None, None, text
+        elif position == "exact":
+            rest = ""
+        else:
+            rest = m.group("rest")
+
+        if m.group('firstday'):
+            # only day given for start
+            firstday = date.parse(m.group('firstday'))
+            start = hamsterday_start(firstday)
+        else:
+            firstday = None
+            start = datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
+                                                   default_day=default_day)
+            if isinstance(start, dt.timedelta):
+                # relative to ref, actually
+                delta1 = start
+                start = ref + delta1
+
+        if m.group('lastday'):
+            lastday = date.parse(m.group('lastday'))
+            end = hamsterday_end(lastday)
+        elif firstday:
+            end = hamsterday_end(firstday)
+        else:
+            end =  datetime._extract_datetime(m, d="date2", h="hour2", m="minute2", r="relative2",
+                                                  default_day=datetime_to_hamsterday(start))
+            if isinstance(end, dt.timedelta):
+                # relative to start, actually
+                delta2 = end
+                if delta2 > dt.timedelta(0):
+                    # wip: currently not reachable (would need [-\+]\d{1,3} in the parser).
+                    end = start + delta2
+                elif ref and delta2 < dt.timedelta(0):
+                    end = ref + delta2
+                else:
+                    end = None
+
+        return start, end, rest
+
+    @classmethod
+    def pattern(cls):
+        return dedent(r"""
+            (                    # start
+              {}                 # datetime: relative1 or (date1, hour1, and minute1)
+              |                  # or
+              (?P<firstday>{})  # date without time
+            )
+            (
+
+                (?P<separation>   # (only needed if end time is given)
+                    \s?           # maybe one space
+                    -             # dash
+                    \s?           # maybe one space
+                  |               # or
+                    \s            # one space exactly
+                )
+            (                     # end
+              {}                  # datetime: relative2 or (date2, hour2, and minute2)
+              |                   # or
+              (?P<lastday>{})     # date without time
+            )
+            )?                    # end time is facultative
+            """.format(datetime.pattern(1), date.pattern(detailed=False),
+                       datetime.pattern(2), date.pattern(detailed=False))
+            )
 
 # no need to change this one for now
 timedelta = dt.timedelta

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -1,18 +1,55 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-"""Python datetime.datetime replacement, tuned for hamster use."""
+"""Hamster datetime.
+
+Python datetime replacement, tuned for hamster use.
+"""
 
 
 import logging
 logger = logging.getLogger(__name__)   # noqa: E402
 
-import datetime as dt
+import datetime as dt  # standard datetime
+import re
 
 
 DATE_FMT = "%Y-%m-%d"  # ISO format
 TIME_FMT = "%H:%M"
 DATETIME_FMT = "{} {}".format(DATE_FMT, TIME_FMT)
+
+
+class date(dt.date):
+    """Hamster date.
+
+    Should replace the python datetime.date in any customer code.
+
+    Same a python date, with the addition of parse methods.
+    """
+
+    FMT = "%Y-%m-%d"  # ISO format
+    basic_pattern = r"""\d{4}-\d{2}-\d{2}"""
+    basic_re = re.compile(basic_pattern, flags=re.VERBOSE)
+    detailed_pattern = r"""
+        (?P<year>\d{4})        # 4 digits
+        -                      # dash
+        (?P<month>\d{2})       # 2 digits
+        -                      # dash
+        (?P<day>\d{2})         # 2 digits
+    """
+    detailed_re = re.compile(detailed_pattern, flags=re.VERBOSE)
+
+    def __new__(cls, year, month, day):
+        return dt.date.__new__(cls, year, month, day)
+
+    @classmethod
+    def parse(cls, s):
+        """Return date from string."""
+        m = cls.detailed_re.search(s)
+        return cls(year=int(m.group('year')),
+                   month=int(m.group('month')),
+                   day=int(m.group('day'))
+                   )
 
 
 class datetime(dt.datetime):

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -1,3 +1,5 @@
+# This file is part of Hamster
+# Copyright (c) The Hamster time tracker developers
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -189,6 +189,12 @@ class datetime(pdt.datetime):
         else:
             raise NotImplementedError("subtract {}".format(type(other)))
 
+    def __str__(self):
+        if self.tzinfo:
+            raise NotImplementedError("Stay tuned...")
+        else:
+            return self.strftime(DATETIME_FMT)
+
     @classmethod
     def _extract_datetime(cls, match, d="date", h="hour", m="minute", r="relative", default_day=None):
         """extract datetime from a datetime.pattern match.
@@ -278,12 +284,6 @@ class datetime(pdt.datetime):
                             self.hour, self.minute,
                             self.second, self.microsecond,
                             self.tzinfo, fold=self.fold)
-
-    def __str__(self):
-        if self.tzinfo:
-            raise NotImplementedError("Stay tuned...")
-        else:
-            return self.strftime(DATETIME_FMT)
 
 
 # outside class; need the class to be defined first

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -18,7 +18,7 @@ from textwrap import dedent
 from functools import lru_cache
 
 # to be replaced soon
-from hamster.lib.stuff import hamster_today, hamsterday_end, hamsterday_start, hamsterday_time_to_datetime
+from hamster.lib.stuff import hamsterday_end, hamsterday_start, hamsterday_time_to_datetime
 
 DATE_FMT = "%Y-%m-%d"  # ISO format
 TIME_FMT = "%H:%M"
@@ -243,7 +243,7 @@ class datetime(pdt.datetime):
         default_day (dt.date):
             If start is given without any date (e.g. just hh:mm),
             put the corresponding datetime in default_day.
-            Defaults to hamster_today.
+            Defaults to today.
         """
 
         # datetime.re is added below, after the class definition
@@ -315,7 +315,7 @@ class Range(namedtuple('Range', 'start, end')):
 
         default_day (date): If start is given without any date (e.g. just hh:mm),
                                put the corresponding datetime in default_day.
-                               Defaults to hamster_today.
+                               Defaults to today.
                                Note: the default end day is always the start day, so
                                      "2019-11-27 23:50 - 00:20" lasts 30 minutes.
 
@@ -335,7 +335,7 @@ class Range(namedtuple('Range', 'start, end')):
             ref = datetime.now()
 
         if default_day is None:
-            default_day = hamster_today()
+            default_day = today()
 
         assert position in ("exact", "head", "tail"), "position unknown: '{}'".format(position)
         if position == "exact":
@@ -492,3 +492,8 @@ def get_day(civil_date_time):
         hamster_date_time = civil_date_time
     # return only the date
     return hamster_date_time.date()
+
+
+def today():
+    """Return the current day."""
+    return get_day(datetime.now())

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)   # noqa: E402
 import datetime as dt  # standard datetime
 import re
 
+from collections import namedtuple
 from textwrap import dedent
 
 # to be replaced soon
@@ -249,12 +250,12 @@ class datetime(dt.datetime):
 datetime.re = re.compile(datetime.pattern(), flags=re.VERBOSE)
 
 
-class Range():
-    def __init__(self, start, end=None):
-        self.start = start
-        self.end = end
+class Range(namedtuple('Range', 'start, end')):
+    """Time span between two datetimes."""
 
-    # I know, that should return a Range. Let's finish the move first.
+    # slight memory optimization; no further attributes besides start or end.
+    __slots__ = ()
+
     @classmethod
     def parse(cls, text,
               position="exact", separator="\s+", default_day=None, ref="now"):
@@ -280,8 +281,10 @@ class Range():
                             and replaced with hamster_now mocking in pytest).
                            For users, it should be "now".
         Return:
-            (start, end, rest)
-            """
+            (range, rest)
+            range (Range): Range(None, None) if no match is found.
+            rest (str): remainder of the text.
+        """
 
         if ref == "now":
             ref = hamster_now()
@@ -304,7 +307,7 @@ class Range():
         m = re.search(p, text, flags=re.VERBOSE)
 
         if not m:
-            return None, None, text
+            return Range(None, None), text
         elif position == "exact":
             rest = ""
         else:
@@ -342,7 +345,7 @@ class Range():
                 else:
                     end = None
 
-        return start, end, rest
+        return Range(start, end), rest
 
     @classmethod
     def pattern(cls):
@@ -370,6 +373,7 @@ class Range():
             """.format(datetime.pattern(1), date.pattern(detailed=False),
                        datetime.pattern(2), date.pattern(detailed=False))
             )
+
 
 # no need to change this one for now
 timedelta = dt.timedelta

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -118,9 +118,9 @@ class time(pdt.time):
                 tzinfo=None, fold=0):
             # round down to zero seconds and microseconds
             return pdt.time.__new__(cls,
-                                   hour=hour, minute=minute,
-                                   second=0, microsecond=0,
-                                   tzinfo=None, fold=fold)
+                                    hour=hour, minute=minute,
+                                    second=0, microsecond=0,
+                                    tzinfo=None, fold=fold)
 
     @classmethod
     def _extract_time(cls, match, h="hour", m="minute"):
@@ -196,9 +196,9 @@ class datetime(pdt.datetime):
                 tzinfo=None, *, fold=0):
             # round down to zero seconds and microseconds
             return pdt.datetime.__new__(cls, year, month, day,
-                                       hour=hour, minute=minute,
-                                       second=0, microsecond=0,
-                                       tzinfo=None, fold=fold)
+                                        hour=hour, minute=minute,
+                                        second=0, microsecond=0,
+                                        tzinfo=None, fold=fold)
 
     def __add__(self, other):
         # python datetime.__add__ was not type stable prior to 3.8
@@ -230,7 +230,8 @@ class datetime(pdt.datetime):
             return self.strftime(DATETIME_FMT)
 
     @classmethod
-    def _extract_datetime(cls, match, d="date", h="hour", m="minute", r="relative", default_day=None):
+    def _extract_datetime(cls, match, d="date", h="hour", m="minute", r="relative",
+                          default_day=None):
         """extract datetime from a datetime.pattern match.
 
         Custom group names allow to use the same method
@@ -314,7 +315,8 @@ class datetime(pdt.datetime):
         # remove the indentation => easier debugging.
         base_pattern = dedent(r"""
             (?P<whole>
-                                              # (need to double the brackets for .format)
+                                              # note: need to double the brackets
+                                              #       for .format
                 (?<!\d{{2}})                  # negative lookbehind,
                                               # avoid matching 2019-12 or 2019-12-05
                 (?P<relative>-\d{{1,3}})      # minus 1, 2 or 3 digits: relative time
@@ -416,8 +418,9 @@ class Range(namedtuple('Range', 'start, end')):
             start = firstday.start
         else:
             firstday = None
-            start = datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
-                                                   default_day=default_day)
+            start = datetime._extract_datetime(m, d="date1", h="hour1",
+                                               m="minute1", r="relative1",
+                                               default_day=default_day)
             if isinstance(start, pdt.timedelta):
                 # relative to ref, actually
                 delta1 = start
@@ -429,13 +432,15 @@ class Range(namedtuple('Range', 'start, end')):
         elif firstday:
             end = firstday.end
         else:
-            end =  datetime._extract_datetime(m, d="date2", h="hour2", m="minute2", r="relative2",
-                                                  default_day=get_day(start))
+            end = datetime._extract_datetime(m, d="date2", h="hour2",
+                                             m="minute2", r="relative2",
+                                             default_day=get_day(start))
             if isinstance(end, pdt.timedelta):
                 # relative to start, actually
                 delta2 = end
                 if delta2 > pdt.timedelta(0):
-                    # wip: currently not reachable (would need [-\+]\d{1,3} in the parser).
+                    # wip: currently not reachable
+                    # (would need [-\+]\d{1,3} in the parser).
                     end = start + delta2
                 elif ref and delta2 < pdt.timedelta(0):
                     end = ref + delta2
@@ -469,9 +474,7 @@ class Range(namedtuple('Range', 'start, end')):
             )
             )?                    # end time is facultative
             """.format(datetime.pattern(1), date.pattern(detailed=False),
-                       datetime.pattern(2), date.pattern(detailed=False))
-            )
-
+                       datetime.pattern(2), date.pattern(detailed=False)))
 
 
 class timedelta(pdt.timedelta):

--- a/src/hamster/lib/dbus.py
+++ b/src/hamster/lib/dbus.py
@@ -1,8 +1,8 @@
-import datetime as dt
 import dbus
 import dbus.service
 from calendar import timegm
 from dbus.mainloop.glib import DBusGMainLoop as DBusMainLoop
+from hamster.lib import datetime as dt
 from hamster.lib.fact import Fact
 
 

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -23,13 +23,23 @@ class FactError(Exception):
 
 class Fact(object):
     def __init__(self, activity="", category=None, description=None, tags=None,
-                 range=None, start_time=None, end_time=None, id=None, activity_id=None):
+                 range=None, start=None, end=None, start_time=None, end_time=None,
+                 id=None, activity_id=None):
         """Homogeneous chunk of activity.
 
         The category, description and tags must be passed explicitly.
 
         To provide the whole fact information as a single string,
         please use Fact.parse(string).
+
+        range (dt.Range): time spanned by the fact. For convenience,
+                          the `start` and `end` arguments can be given instead.
+        start (dt.datetime); Start of the fact range.
+                             Mutually exclusive with `range`.
+        end (dt.datetime); End of the fact range.
+                           Mutually exclusive with `range`.
+        start_time (dt.datetime): Deprecated. Same as start.
+        end_time (dt.datetime): Deprecated. Same as end.
 
         id (int): id in the database.
                   Should be used with extreme caution, knowing exactly why.
@@ -41,11 +51,19 @@ class Fact(object):
         self.description = description
         self.tags = tags or []
         if range:
+            assert not start, "range already given"
+            assert not end, "range already given"
             assert not start_time, "range already given"
             assert not end_time, "range already given"
             self.range = range
         else:
-            self.range = dt.Range(start_time, end_time)
+            if start_time:
+                assert not start, "use only start, not start_time"
+                start = start_time
+            if end_time:
+                assert not end, "use only end, not end_time"
+                end = end_time
+            self.range = dt.Range(start, end)
         self.id = id
         self.activity_id = activity_id
 

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+"""Fact definition."""
+
+
 import logging
 logger = logging.getLogger(__name__)   # noqa: E402
 

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -14,9 +14,7 @@ from textwrap import dedent
 
 from hamster.lib import datetime as dt
 from hamster.lib.parsing import TIME_FMT, DATETIME_FMT, parse_fact
-from hamster.lib.stuff import (
-    hamsterday_time_to_datetime,
-)
+
 
 class FactError(Exception):
     """Generic Fact error."""
@@ -104,13 +102,13 @@ class Fact(object):
     def date(self, value):
         if self.start_time:
             previous_start_time = self.start_time
-            self.start_time = hamsterday_time_to_datetime(value, self.start_time.time())
+            self.start_time = dt.datetime.from_day_time(value, self.start_time.time())
             if self.end_time:
                 # start_time date prevails.
                 # Shift end_time to preserve the fact duration.
                 self.end_time += self.start_time - previous_start_time
         elif self.end_time:
-            self.end_time = hamsterday_time_to_datetime(value, self.end_time.time())
+            self.end_time = dt.datetime.from_day_time(value, self.end_time.time())
 
     @property
     def delta(self):

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -23,7 +23,7 @@ class FactError(Exception):
 
 class Fact(object):
     def __init__(self, activity="", category=None, description=None, tags=None,
-                 start_time=None, end_time=None, id=None, activity_id=None):
+                 range=None, start_time=None, end_time=None, id=None, activity_id=None):
         """Homogeneous chunk of activity.
 
         The category, description and tags must be passed explicitly.
@@ -40,8 +40,12 @@ class Fact(object):
         self.category = category
         self.description = description
         self.tags = tags or []
-        self.start_time = start_time
-        self.end_time = end_time
+        if range:
+            assert not start_time, "range already given"
+            assert not end_time, "range already given"
+            self.range = range
+        else:
+            self.range = dt.Range(start_time, end_time)
         self.id = id
         self.activity_id = activity_id
 
@@ -125,8 +129,21 @@ class Fact(object):
     def description(self, value):
         self._description = value.strip() if value else ""
 
+    @property
+    def end_time(self):
+        return self.range.end
 
+    @end_time.setter
+    def end_time(self, value):
+        self.range.end = value
 
+    @property
+    def start_time(self):
+        return self.range.start
+
+    @start_time.setter
+    def start_time(self, value):
+        self.range.start = value
 
     @classmethod
     def parse(cls, string, range_pos="head", default_day=None, ref="now"):

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -16,7 +16,6 @@ from hamster.lib import datetime as dt
 from hamster.lib.parsing import TIME_FMT, DATETIME_FMT, parse_fact
 from hamster.lib.stuff import (
     hamsterday_time_to_datetime,
-    hamster_today,
 )
 
 class FactError(Exception):

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -8,11 +8,11 @@ import logging
 logger = logging.getLogger(__name__)   # noqa: E402
 
 import calendar
-import datetime as dt
 
 from copy import deepcopy
 from textwrap import dedent
 
+from hamster.lib import datetime as dt
 from hamster.lib.parsing import TIME_FMT, DATETIME_FMT, parse_fact
 from hamster.lib.stuff import (
     datetime_to_hamsterday,

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -59,7 +59,7 @@ class Fact(object):
             'description': self.description,
             'tags': [tag.strip() for tag in self.tags],
             'date': calendar.timegm(date.timetuple()) if date else "",
-            'start_time': self.start_time if isinstance(self.start_time, str) else calendar.timegm(self.start_time.timetuple()),
+            'start_time': self.range.start if isinstance(self.range.start, str) else calendar.timegm(self.range.start.timetuple()),
             'end_time': self.end_time if isinstance(self.end_time, str) else calendar.timegm(self.end_time.timetuple()) if self.end_time else "",
             'delta': self.delta.total_seconds()  # ugly, but needed for report.py
         }
@@ -101,17 +101,17 @@ class Fact(object):
               Any subsequent modification of start_time
               can result in different self.date.
         """
-        return self.start_time.hday()
+        return self.range.start.hday()
 
     @date.setter
     def date(self, value):
-        if self.start_time:
-            previous_start_time = self.start_time
-            self.start_time = dt.datetime.from_day_time(value, self.start_time.time())
+        if self.range.start:
+            previous_start_time = self.range.start
+            self.range.start = dt.datetime.from_day_time(value, self.range.start.time())
             if self.end_time:
                 # start_time date prevails.
                 # Shift end_time to preserve the fact duration.
-                self.end_time += self.start_time - previous_start_time
+                self.end_time += self.range.start - previous_start_time
         elif self.end_time:
             self.end_time = dt.datetime.from_day_time(value, self.end_time.time())
 
@@ -119,7 +119,7 @@ class Fact(object):
     def delta(self):
         """Duration (datetime.timedelta)."""
         end_time = self.end_time if self.end_time else dt.datetime.now()
-        return end_time - self.start_time
+        return end_time - self.range.start
 
     @property
     def description(self):
@@ -131,6 +131,10 @@ class Fact(object):
 
     @property
     def end_time(self):
+        """Fact range end.
+
+        Deprecated, use self.range.end instead.
+        """
         return self.range.end
 
     @end_time.setter
@@ -139,6 +143,10 @@ class Fact(object):
 
     @property
     def start_time(self):
+        """Fact range start.
+
+        Deprecated, use self.range.start instead.
+        """
         return self.range.start
 
     @start_time.setter
@@ -184,13 +192,13 @@ class Fact(object):
         the same hamster day as start.
         """
         time_str = ""
-        if self.start_time:
-            if self.start_time.hday() != default_day:
-                time_str += self.start_time.strftime(DATETIME_FMT)
+        if self.range.start:
+            if self.range.start.hday() != default_day:
+                time_str += self.range.start.strftime(DATETIME_FMT)
             else:
-                time_str += self.start_time.strftime(TIME_FMT)
+                time_str += self.range.start.strftime(TIME_FMT)
         if self.end_time:
-            if self.end_time.hday() != self.start_time.hday():
+            if self.end_time.hday() != self.range.start.hday():
                 end_time_str = self.end_time.strftime(DATETIME_FMT)
             else:
                 end_time_str = self.end_time.strftime(TIME_FMT)
@@ -213,7 +221,7 @@ class Fact(object):
         """Modify attributes.
 
         Private, used only in copy. It is more readable to be explicit, e.g.:
-        fact.start_time = ...
+        fact.range.start = ...
         fact.end_time = ...
         """
         for attr, value in kwds.items():
@@ -228,7 +236,7 @@ class Fact(object):
                 and self.category == other.category
                 and self.description == other.description
                 and self.end_time == other.end_time
-                and self.start_time == other.start_time
+                and self.range.start == other.range.start
                 and self.tags == other.tags
                 )
 

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -15,7 +15,6 @@ from textwrap import dedent
 from hamster.lib import datetime as dt
 from hamster.lib.parsing import TIME_FMT, DATETIME_FMT, parse_fact
 from hamster.lib.stuff import (
-    datetime_to_hamsterday,
     hamsterday_time_to_datetime,
     hamster_now,
     hamster_today,
@@ -101,7 +100,7 @@ class Fact(object):
               Any subsequent modification of start_time
               can result in different self.date.
         """
-        return datetime_to_hamsterday(self.start_time)
+        return dt.get_day(self.start_time)
 
     @date.setter
     def date(self, value):
@@ -169,12 +168,12 @@ class Fact(object):
         """
         time_str = ""
         if self.start_time:
-            if datetime_to_hamsterday(self.start_time) != default_day:
+            if dt.get_day(self.start_time) != default_day:
                 time_str += self.start_time.strftime(DATETIME_FMT)
             else:
                 time_str += self.start_time.strftime(TIME_FMT)
         if self.end_time:
-            if datetime_to_hamsterday(self.end_time) != datetime_to_hamsterday(self.start_time):
+            if dt.get_day(self.end_time) != dt.get_day(self.start_time):
                 end_time_str = self.end_time.strftime(DATETIME_FMT)
             else:
                 end_time_str = self.end_time.strftime(TIME_FMT)

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -16,7 +16,6 @@ from hamster.lib import datetime as dt
 from hamster.lib.parsing import TIME_FMT, DATETIME_FMT, parse_fact
 from hamster.lib.stuff import (
     hamsterday_time_to_datetime,
-    hamster_now,
     hamster_today,
 )
 
@@ -117,7 +116,7 @@ class Fact(object):
     @property
     def delta(self):
         """Duration (datetime.timedelta)."""
-        end_time = self.end_time if self.end_time else hamster_now()
+        end_time = self.end_time if self.end_time else dt.datetime.now()
         return end_time - self.start_time
 
     @property

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -1,3 +1,5 @@
+# This file is part of Hamster
+# Copyright (c) The Hamster time tracker developers
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -60,7 +60,7 @@ class Fact(object):
             'tags': [tag.strip() for tag in self.tags],
             'date': calendar.timegm(date.timetuple()) if date else "",
             'start_time': self.range.start if isinstance(self.range.start, str) else calendar.timegm(self.range.start.timetuple()),
-            'end_time': self.end_time if isinstance(self.end_time, str) else calendar.timegm(self.end_time.timetuple()) if self.end_time else "",
+            'end_time': self.range.end if isinstance(self.range.end, str) else calendar.timegm(self.range.end.timetuple()) if self.range.end else "",
             'delta': self.delta.total_seconds()  # ugly, but needed for report.py
         }
 
@@ -108,17 +108,17 @@ class Fact(object):
         if self.range.start:
             previous_start_time = self.range.start
             self.range.start = dt.datetime.from_day_time(value, self.range.start.time())
-            if self.end_time:
+            if self.range.end:
                 # start_time date prevails.
                 # Shift end_time to preserve the fact duration.
-                self.end_time += self.range.start - previous_start_time
-        elif self.end_time:
-            self.end_time = dt.datetime.from_day_time(value, self.end_time.time())
+                self.range.end += self.range.start - previous_start_time
+        elif self.range.end:
+            self.range.end = dt.datetime.from_day_time(value, self.range.end.time())
 
     @property
     def delta(self):
         """Duration (datetime.timedelta)."""
-        end_time = self.end_time if self.end_time else dt.datetime.now()
+        end_time = self.range.end if self.range.end else dt.datetime.now()
         return end_time - self.range.start
 
     @property
@@ -197,11 +197,11 @@ class Fact(object):
                 time_str += self.range.start.strftime(DATETIME_FMT)
             else:
                 time_str += self.range.start.strftime(TIME_FMT)
-        if self.end_time:
-            if self.end_time.hday() != self.range.start.hday():
-                end_time_str = self.end_time.strftime(DATETIME_FMT)
+        if self.range.end:
+            if self.range.end.hday() != self.range.start.hday():
+                end_time_str = self.range.end.strftime(DATETIME_FMT)
             else:
-                end_time_str = self.end_time.strftime(TIME_FMT)
+                end_time_str = self.range.end.strftime(TIME_FMT)
             time_str = "{} - {}".format(time_str, end_time_str)
         return time_str
 
@@ -222,7 +222,7 @@ class Fact(object):
 
         Private, used only in copy. It is more readable to be explicit, e.g.:
         fact.range.start = ...
-        fact.end_time = ...
+        fact.range.end = ...
         """
         for attr, value in kwds.items():
             if not hasattr(self, attr):
@@ -235,7 +235,7 @@ class Fact(object):
                 and self.activity == other.activity
                 and self.category == other.category
                 and self.description == other.description
-                and self.end_time == other.end_time
+                and self.range.end == other.range.end
                 and self.range.start == other.range.start
                 and self.tags == other.tags
                 )

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -202,31 +202,10 @@ class Fact(object):
             res += " %s" % " ".join("#%s" % tag for tag in self.tags)
         return res
 
-    def serialized_range(self, default_day=None):
-        """Return a string representing the time range.
-
-        Start date is shown only if start does not belong to default_day.
-        End date is shown only if end does not belong to
-        the same hamster day as start.
-        """
-        time_str = ""
-        if self.range.start:
-            if self.range.start.hday() != default_day:
-                time_str += self.range.start.strftime(DATETIME_FMT)
-            else:
-                time_str += self.range.start.strftime(TIME_FMT)
-        if self.range.end:
-            if self.range.end.hday() != self.range.start.hday():
-                end_time_str = self.range.end.strftime(DATETIME_FMT)
-            else:
-                end_time_str = self.range.end.strftime(TIME_FMT)
-            time_str = "{} - {}".format(time_str, end_time_str)
-        return time_str
-
     def serialized(self, range_pos="head", default_day=None):
         """Return a string fully representing the fact."""
         name = self.serialized_name()
-        datetime = self.serialized_range(default_day)
+        datetime = self.range.format(default_day=default_day)
         # no need for space if name or datetime is missing
         space = " " if name and datetime else ""
         assert range_pos in ("head", "tail")

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -98,7 +98,7 @@ class Fact(object):
               Any subsequent modification of start_time
               can result in different self.date.
         """
-        return dt.get_day(self.start_time)
+        return self.start_time.hday()
 
     @date.setter
     def date(self, value):
@@ -125,6 +125,9 @@ class Fact(object):
     @description.setter
     def description(self, value):
         self._description = value.strip() if value else ""
+
+
+
 
     @classmethod
     def parse(cls, string, range_pos="head", default_day=None, ref="now"):
@@ -166,12 +169,12 @@ class Fact(object):
         """
         time_str = ""
         if self.start_time:
-            if dt.get_day(self.start_time) != default_day:
+            if self.start_time.hday() != default_day:
                 time_str += self.start_time.strftime(DATETIME_FMT)
             else:
                 time_str += self.start_time.strftime(TIME_FMT)
         if self.end_time:
-            if dt.get_day(self.end_time) != dt.get_day(self.start_time):
+            if self.end_time.hday() != self.start_time.hday():
                 end_time_str = self.end_time.strftime(DATETIME_FMT)
             else:
                 end_time_str = self.end_time.strftime(TIME_FMT)

--- a/src/hamster/lib/graphics.py
+++ b/src/hamster/lib/graphics.py
@@ -7,6 +7,7 @@
 
 from collections import defaultdict
 import math
+import datetime as dt  # need the original python granularity here
 
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
@@ -27,7 +28,6 @@ except: # we can also live without tweener. Scene.animate will not work
 import colorsys
 from collections import deque
 
-from hamster.lib import datetime as dt
 
 
 # lemme know if you know a better way how to get default font

--- a/src/hamster/lib/graphics.py
+++ b/src/hamster/lib/graphics.py
@@ -7,8 +7,6 @@
 
 from collections import defaultdict
 import math
-import datetime as dt
-
 
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
@@ -28,6 +26,9 @@ except: # we can also live without tweener. Scene.animate will not work
 
 import colorsys
 from collections import deque
+
+from hamster.lib import datetime as dt
+
 
 # lemme know if you know a better way how to get default font
 _test_label = gtk.Label("Hello")

--- a/src/hamster/lib/layout.py
+++ b/src/hamster/lib/layout.py
@@ -4,7 +4,6 @@
 # Copyright (c) 2014 Toms Baugis <toms.baugis@gmail.com>
 # Dual licensed under the MIT or GPL Version 2 licenses.
 
-import datetime as dt
 import math
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
@@ -12,6 +11,7 @@ from gi.repository import GObject as gobject
 from gi.repository import Pango as pango
 from collections import defaultdict
 
+from hamster.lib import datetime as dt
 from hamster.lib import graphics
 
 

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -5,7 +5,6 @@ import re
 
 from hamster.lib import datetime as dt
 from hamster.lib.stuff import (
-    hamster_today,
     hamsterday_end,
     hamsterday_start,
     hamsterday_time_to_datetime,

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -4,9 +4,6 @@ logger = logging.getLogger(__name__)   # noqa: E402
 import re
 
 from hamster.lib import datetime as dt
-from hamster.lib.stuff import (
-    hamsterday_end,
-)
 
 
 DATE_FMT = "%Y-%m-%d"  # ISO format

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -15,6 +15,7 @@ from hamster.lib.stuff import (
 )
 
 
+# to be removed once hamster.lib/datetime is up and running
 DATE_FMT = "%Y-%m-%d"  # ISO format
 TIME_FMT = "%H:%M"
 DATETIME_FMT = "{} {}".format(DATE_FMT, TIME_FMT)

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -43,20 +43,6 @@ tags_separator = re.compile(r"""
 """, flags=re.VERBOSE)
 
 
-
-
-
-# needed for range_pattern
-def specific_dt_pattern(n):
-    """Return a datetime pattern with all group names suffixed with n."""
-    to_replace = ("whole", "relative", "year", "month", "day", "date", "tens", "hour", "minute")
-    specifics = ["{}{}".format(s, n) for s in to_replace]
-    res = hdt.datetime.pattern
-    for src, dest in zip(to_replace, specifics):
-        res = res.replace(src, dest)
-    return res
-
-
 range_pattern = r"""
     (                    # start
       {}                 # datetime: relative1 or (date1, hour1, and minute1)
@@ -78,8 +64,8 @@ range_pattern = r"""
       (?P<lastday>{})     # date without time
     )
     )?                    # end time is facultative
-""".format(specific_dt_pattern(1), hdt.date.basic_pattern,
-           specific_dt_pattern(2), hdt.date.basic_pattern)
+""".format(hdt.datetime.pattern(1), hdt.date.basic_pattern,
+           hdt.datetime.pattern(2), hdt.date.basic_pattern)
 
 
 def parse_datetime_range(text, position="exact", separator="\s+", default_day=None, ref="now"):

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -5,7 +5,6 @@ import re
 
 from hamster.lib import datetime as dt
 from hamster.lib.stuff import (
-    hamster_now,
     hamster_today,
     hamsterday_end,
     hamsterday_start,

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -15,7 +15,6 @@ from hamster.lib.stuff import (
 )
 
 
-# to be removed once hamster.lib/datetime is up and running
 DATE_FMT = "%Y-%m-%d"  # ISO format
 TIME_FMT = "%H:%M"
 DATETIME_FMT = "{} {}".format(DATE_FMT, TIME_FMT)
@@ -133,6 +132,9 @@ range_pattern = r"""
 def _extract_time(match, h="hour", m="minute"):
     """Extract time from a time_re match.
 
+    Custom group names allow to use the same method
+    for two times in the same regexp (e.g. for range parsing)
+
     h (str): name of the group containing the hour
     m (str): name of the group containing the minute
     """
@@ -163,6 +165,9 @@ def parse_date(s):
 
 def _extract_datetime(match, d="date", h="hour", m="minute", r="relative", default_day=None):
     """extract datetime from a dt_pattern match.
+
+    Custom group names allow to use the same method
+    for two datetimes in the same regexp (e.g. for range parsing)
 
     h (str): name of the group containing the hour
     m (str): name of the group containing the minute

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -5,7 +5,6 @@ import re
 
 from hamster.lib import datetime as dt
 from hamster.lib.stuff import (
-    datetime_to_hamsterday,
     hamster_now,
     hamster_today,
     hamsterday_end,

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -7,7 +7,6 @@ from hamster.lib import datetime as dt
 from hamster.lib.stuff import (
     hamsterday_end,
     hamsterday_start,
-    hamsterday_time_to_datetime,
 )
 
 

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -6,7 +6,6 @@ import re
 from hamster.lib import datetime as dt
 from hamster.lib.stuff import (
     hamsterday_end,
-    hamsterday_start,
 )
 
 

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -64,8 +64,8 @@ range_pattern = r"""
       (?P<lastday>{})     # date without time
     )
     )?                    # end time is facultative
-""".format(hdt.datetime.pattern(1), hdt.date.basic_pattern,
-           hdt.datetime.pattern(2), hdt.date.basic_pattern)
+""".format(hdt.datetime.pattern(1), hdt.date.pattern(detailed=False),
+           hdt.datetime.pattern(2), hdt.date.pattern(detailed=False))
 
 
 def parse_datetime_range(text, position="exact", separator="\s+", default_day=None, ref="now"):

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -61,9 +61,9 @@ def parse_fact(text, range_pos="head", default_day=None, ref="now"):
 
     # datetimes
     # force at least a space to avoid matching 10.00@cat
-    start, end, remaining_text = hdt.Range.parse(text, position=range_pos,
-                                                 separator=ACTIVITY_SEPARATOR,
-                                                 default_day=default_day)
+    (start, end), remaining_text = hdt.Range.parse(text, position=range_pos,
+                                                   separator=ACTIVITY_SEPARATOR,
+                                                   default_day=default_day)
     res["start_time"] = start
     res["end_time"] = end
 

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -1,10 +1,9 @@
 import logging
 logger = logging.getLogger(__name__)   # noqa: E402
 
-import datetime as dt
 import re
 
-from hamster.lib import datetime as hdt
+from hamster.lib import datetime as dt
 from hamster.lib.stuff import (
     datetime_to_hamsterday,
     hamster_now,
@@ -61,7 +60,7 @@ def parse_fact(text, range_pos="head", default_day=None, ref="now"):
 
     # datetimes
     # force at least a space to avoid matching 10.00@cat
-    (start, end), remaining_text = hdt.Range.parse(text, position=range_pos,
+    (start, end), remaining_text = dt.Range.parse(text, position=range_pos,
                                                    separator=ACTIVITY_SEPARATOR,
                                                    default_day=default_day)
     res["start_time"] = start

--- a/src/hamster/lib/pytweener.py
+++ b/src/hamster/lib/pytweener.py
@@ -9,9 +9,10 @@
 # All kinds of slashing and dashing by Toms Baugis 2010, 2014
 import math
 import collections
-import datetime as dt
 import time
 import re
+
+from hamster.lib import datetime as dt
 
 class Tweener(object):
     def __init__(self, default_duration = None, tween = None):

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -53,14 +53,6 @@ def hamster_round(time):
         return time.replace(second=0, microsecond=0)
 
 
-def hamsterday_start(hamsterday):
-    """Return the given day start, as a datetime."""
-
-    # work around cyclic imports
-    from hamster.lib.configuration import conf
-    return dt.datetime.from_day_time(hamsterday, conf.day_start)
-
-
 def hamsterday_end(hamsterday):
     """Return the given day end, as a datetime."""
 

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -24,9 +24,6 @@
 import logging
 logger = logging.getLogger(__name__)   # noqa: E402
 
-import gi
-
-gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk as gtk
 from gi.repository import Pango as pango
 

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -43,7 +43,10 @@ from hamster.lib import datetime as dt
 
 
 def hamster_round(time):
-    """Round time or datetime."""
+    """Round time or datetime.
+
+    Deprecated: hamster.lib/datetime.time or datetime are already rounded.
+    """
     if time is None:
         return None
     else:
@@ -52,7 +55,10 @@ def hamster_round(time):
 
 def format_duration(minutes, human = True):
     """formats duration in a human readable format.
-    accepts either minutes or timedelta"""
+    accepts either minutes or timedelta
+
+    Deprecated: use timedelta.format() instead.
+    """
 
     minutes = duration_minutes(minutes)
 

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -53,14 +53,6 @@ def hamster_round(time):
         return time.replace(second=0, microsecond=0)
 
 
-def hamsterday_end(hamsterday):
-    """Return the given day end, as a datetime."""
-
-    # work around cyclic imports
-    from hamster.lib.configuration import conf
-    return dt.datetime.from_day_time(hamsterday + dt.timedelta(days=1), conf.day_start)
-
-
 def format_duration(minutes, human = True):
     """formats duration in a human readable format.
     accepts either minutes or timedelta"""

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -40,11 +40,8 @@ import os
 from hamster.lib import datetime as dt
 
 # datetime_to_hamsterday = dt.get_day
+# hamster_now = dt.datetime.now
 
-
-def hamster_now():
-    # current datetime truncated to the minute
-    return hamster_round(dt.datetime.now())
 
 
 def hamster_round(time):
@@ -57,7 +54,7 @@ def hamster_round(time):
 
 def hamster_today():
     """Return the current hamster day."""
-    return dt.get_day(hamster_now())
+    return dt.get_day(dt.datetime.now())
 
 
 def hamsterday_time_to_datetime(hamsterday, time):

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -118,8 +118,7 @@ def format_duration(minutes, human = True):
     """formats duration in a human readable format.
     accepts either minutes or timedelta"""
 
-    if isinstance(minutes, dt.timedelta):
-        minutes = duration_minutes(minutes)
+    minutes = duration_minutes(minutes)
 
     if not minutes:
         if human:
@@ -203,16 +202,17 @@ def month(view_date):
 
 def duration_minutes(duration):
     """returns minutes from duration, otherwise we keep bashing in same math"""
-    if isinstance(duration, list):
+    if isinstance(duration, dt.timedelta):
+        return duration.total_seconds() / 60
+    elif isinstance(duration, (int, float)):
+        return duration
+    elif isinstance(duration, list):
         res = dt.timedelta()
         for entry in duration:
             res += entry
-
         return duration_minutes(res)
-    elif isinstance(duration, dt.timedelta):
-        return duration.total_seconds() / 60
     else:
-        return duration
+        raise NotImplementedError("received {}".format(type(duration)))
 
 
 def zero_hour(date):

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -38,10 +38,20 @@ from hamster.lib import datetime as dt
 
 
 # for pre-v3.0 backward compatibility
-datetime_to_hamsterday = dt.get_day
 hamster_now = dt.datetime.now
 hamster_today = dt.today
 hamsterday_time_to_datetime = dt.datetime.from_day_time
+
+
+def datetime_to_hamsterday(civil_date_time):
+    """Return the hamster day corresponding to a given civil datetime.
+
+    Deprecated: use civil_date_time.hday() instead
+
+    The hamster day start is taken into account.
+    """
+
+    return civil_date_time.hday()
 
 
 def hamster_round(time):

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -41,7 +41,7 @@ from hamster.lib import datetime as dt
 
 # datetime_to_hamsterday = dt.get_day
 # hamster_now = dt.datetime.now
-
+# hamster_today = dt.today
 
 
 def hamster_round(time):
@@ -50,11 +50,6 @@ def hamster_round(time):
         return None
     else:
         return time.replace(second=0, microsecond=0)
-
-
-def hamster_today():
-    """Return the current hamster day."""
-    return dt.get_day(dt.datetime.now())
 
 
 def hamsterday_time_to_datetime(hamsterday, time):

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -39,27 +39,7 @@ import os
 
 from hamster.lib import datetime as dt
 
-
-def datetime_to_hamsterday(civil_date_time):
-    """Return the hamster day corresponding to a given civil datetime.
-
-    The hamster day start is taken into account.
-    """
-
-    if civil_date_time is None:
-        return None
-
-    # work around cyclic imports
-    from hamster.lib.configuration import conf
-
-    if civil_date_time.time() < conf.day_start:
-        # early morning, between midnight and day_start
-        # => the hamster day is the previous civil day
-        hamster_date_time = civil_date_time - dt.timedelta(days=1)
-    else:
-        hamster_date_time = civil_date_time
-    # return only the date
-    return hamster_date_time.date()
+# datetime_to_hamsterday = dt.get_day
 
 
 def hamster_now():
@@ -77,7 +57,7 @@ def hamster_round(time):
 
 def hamster_today():
     """Return the current hamster day."""
-    return datetime_to_hamsterday(hamster_now())
+    return dt.get_day(hamster_now())
 
 
 def hamsterday_time_to_datetime(hamsterday, time):

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -36,10 +36,12 @@ import os
 
 from hamster.lib import datetime as dt
 
-# datetime_to_hamsterday = dt.get_day
-# hamster_now = dt.datetime.now
-# hamster_today = dt.today
-# hamsterday_time_to_datetime = dt.datetime.from_day_time
+
+# for pre-v3.0 backward compatibility
+datetime_to_hamsterday = dt.get_day
+hamster_now = dt.datetime.now
+hamster_today = dt.today
+hamsterday_time_to_datetime = dt.datetime.from_day_time
 
 
 def hamster_round(time):

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -39,7 +39,7 @@ from hamster.lib import datetime as dt
 
 # for pre-v3.0 backward compatibility
 hamster_now = dt.datetime.now
-hamster_today = dt.today
+hamster_today = dt.hday.today
 hamsterday_time_to_datetime = dt.datetime.from_day_time
 
 

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -25,19 +25,19 @@ import logging
 logger = logging.getLogger(__name__)   # noqa: E402
 
 import gi
-import datetime as dt
 
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk as gtk
 from gi.repository import Pango as pango
 
 from itertools import groupby
-import datetime as dt
 import calendar
 import time
 import re
 import locale
 import os
+
+from hamster.lib import datetime as dt
 
 
 def datetime_to_hamsterday(civil_date_time):

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -42,6 +42,7 @@ from hamster.lib import datetime as dt
 # datetime_to_hamsterday = dt.get_day
 # hamster_now = dt.datetime.now
 # hamster_today = dt.today
+# hamsterday_time_to_datetime = dt.datetime.from_day_time
 
 
 def hamster_round(time):
@@ -52,30 +53,12 @@ def hamster_round(time):
         return time.replace(second=0, microsecond=0)
 
 
-def hamsterday_time_to_datetime(hamsterday, time):
-    """Return the civil datetime corresponding to a given hamster day and time.
-
-    The hamster day start is taken into account.
-    """
-
-    # work around cyclic imports
-    from hamster.lib.configuration import conf
-
-    if time < conf.day_start:
-        # early morning, between midnight and day_start
-        # => the hamster day is the previous civil day
-        civil_date = hamsterday + dt.timedelta(days=1)
-    else:
-        civil_date = hamsterday
-    return dt.datetime.combine(civil_date, time)
-
-
 def hamsterday_start(hamsterday):
     """Return the given day start, as a datetime."""
 
     # work around cyclic imports
     from hamster.lib.configuration import conf
-    return hamsterday_time_to_datetime(hamsterday, conf.day_start)
+    return dt.datetime.from_day_time(hamsterday, conf.day_start)
 
 
 def hamsterday_end(hamsterday):
@@ -83,7 +66,7 @@ def hamsterday_end(hamsterday):
 
     # work around cyclic imports
     from hamster.lib.configuration import conf
-    return hamsterday_time_to_datetime(hamsterday + dt.timedelta(days=1), conf.day_start)
+    return dt.datetime.from_day_time(hamsterday + dt.timedelta(days=1), conf.day_start)
 
 
 def format_duration(minutes, human = True):

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -19,7 +19,6 @@
 
 import sys
 import bisect
-import datetime as dt
 import itertools
 import webbrowser
 
@@ -37,6 +36,7 @@ from gi.repository import Pango as pango
 import cairo
 
 import hamster.client
+from hamster.lib import datetime as dt
 from hamster.lib import graphics
 from hamster.lib import layout
 from hamster import reports

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -67,7 +67,7 @@ class HeaderBar(gtk.HeaderBar):
         gtk.StyleContext.add_class(box.get_style_context(), "linked")
         self.pack_start(box)
 
-        self.range_pick = RangePick(stuff.hamster_today())
+        self.range_pick = RangePick(dt.today())
         self.pack_start(self.range_pick)
 
         self.system_button = gtk.MenuButton()
@@ -460,7 +460,7 @@ class Overview(Controller):
         main.pack_start(self.totals, False, True, 1)
 
         # FIXME: should store and recall date_range from hamster.lib.configuration.conf
-        hamster_day = dt.get_day(dt.datetime.today())
+        hamster_day = dt.today()
         self.header_bar.range_pick.set_range(hamster_day)
         self.header_bar.range_pick.connect("range-selected", self.on_range_selected)
         self.header_bar.add_activity_button.connect("clicked", self.on_add_activity_clicked)

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -25,12 +25,10 @@ import webbrowser
 from collections import defaultdict
 from math import ceil
 
+from gi.repository import GLib as glib
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
 from gi.repository import GObject as gobject
-
-import gi
-gi.require_version('PangoCairo', '1.0')
 from gi.repository import PangoCairo as pangocairo
 from gi.repository import Pango as pango
 import cairo
@@ -583,7 +581,7 @@ class Overview(Controller):
         uri = "help:hamster"
         try:
             gtk.show_uri(None, uri, gdk.CURRENT_TIME)
-        except gi.repository.GLib.Error:
+        except glib.Error:
             msg = sys.exc_info()[1].args[0]
             dialog = gtk.MessageDialog(self.window, 0, gtk.MessageType.ERROR,
                                        gtk.ButtonsType.CLOSE,

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -245,7 +245,7 @@ class HorizontalBarChart(graphics.Sprite):
         bar_start_x = label_width + margin
         for i, (label, value) in enumerate(self.values):
             g.set_color(self.label_color)
-            duration_str = stuff.format_duration(value, human=False)
+            duration_str = value.format(fmt="HH:MM")
             markup_label = stuff.escape_pango(str(label))
             markup_duration = stuff.escape_pango(duration_str)
             self.layout.set_markup("{}, <i>{}</i>".format(markup_label, markup_duration))

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -65,7 +65,7 @@ class HeaderBar(gtk.HeaderBar):
         gtk.StyleContext.add_class(box.get_style_context(), "linked")
         self.pack_start(box)
 
-        self.range_pick = RangePick(dt.today())
+        self.range_pick = RangePick(dt.hday.today())
         self.pack_start(self.range_pick)
 
         self.system_button = gtk.MenuButton()
@@ -458,7 +458,7 @@ class Overview(Controller):
         main.pack_start(self.totals, False, True, 1)
 
         # FIXME: should store and recall date_range from hamster.lib.configuration.conf
-        hamster_day = dt.today()
+        hamster_day = dt.hday.today()
         self.header_bar.range_pick.set_range(hamster_day)
         self.header_bar.range_pick.connect("range-selected", self.on_range_selected)
         self.header_bar.add_activity_button.connect("clicked", self.on_add_activity_clicked)

--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -460,7 +460,7 @@ class Overview(Controller):
         main.pack_start(self.totals, False, True, 1)
 
         # FIXME: should store and recall date_range from hamster.lib.configuration.conf
-        hamster_day = stuff.datetime_to_hamsterday(dt.datetime.today())
+        hamster_day = dt.get_day(dt.datetime.today())
         self.header_bar.range_pick.set_range(hamster_day)
         self.header_bar.range_pick.connect("range-selected", self.on_range_selected)
         self.header_bar.add_activity_button.connect("clicked", self.on_add_activity_clicked)

--- a/src/hamster/preferences.py
+++ b/src/hamster/preferences.py
@@ -21,9 +21,8 @@ from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
 from gi.repository import GObject as gobject
 
-import datetime as dt
-
 from hamster import widgets
+from hamster.lib import datetime as dt
 from hamster.lib import stuff
 from hamster.lib.configuration import Controller, runtime, conf
 

--- a/src/hamster/reports.py
+++ b/src/hamster/reports.py
@@ -20,7 +20,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 import os, sys
-import datetime as dt
 from xml.dom.minidom import Document
 import csv
 import copy
@@ -30,6 +29,7 @@ import codecs
 from string import Template
 from textwrap import dedent
 
+from hamster.lib import datetime as dt
 from hamster.lib.configuration import runtime
 from hamster.lib import stuff
 from hamster.lib.i18n import C_

--- a/src/hamster/reports.py
+++ b/src/hamster/reports.py
@@ -255,7 +255,7 @@ class HTMLWriter(ReportWriter):
             start_iso = fact.start_time.isoformat(),
             end = end_time_str,
             end_iso = end_time_iso_str,
-            duration = stuff.format_duration(fact.delta) or "",
+            duration = fact.delta.format(),
             duration_minutes = "%d" % (stuff.duration_minutes(fact.delta)),
             duration_decimal = "%.2f" % (stuff.duration_minutes(fact.delta) / 60.0),
             description = fact.description or ""

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -673,7 +673,7 @@ class Storage(storage.Storage):
 
 
     def __get_todays_facts(self):
-        return self.__get_facts(dt.today())
+        return self.__get_facts(dt.hday.today())
 
     def __get_facts(self, date, end_date = None, search_terms = ""):
         split_time = conf.day_start

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -25,7 +25,6 @@ import logging
 logger = logging.getLogger(__name__)   # noqa: E402
 
 import os, time
-import datetime as dt
 import itertools
 import sqlite3 as sqlite
 from shutil import copy as copyfile
@@ -35,6 +34,7 @@ except ImportError:
     print("Could not import gio - requires pygobject. File monitoring will be disabled")
     gio = None
 
+from hamster.lib import datetime as dt
 from hamster.lib.configuration import conf
 from hamster.lib.fact import Fact
 from hamster.lib.stuff import hamster_today, hamster_now

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -37,7 +37,7 @@ except ImportError:
 from hamster.lib import datetime as dt
 from hamster.lib.configuration import conf
 from hamster.lib.fact import Fact
-from hamster.lib.stuff import hamster_today, hamster_now
+from hamster.lib.stuff import hamster_today
 from hamster.storage import storage
 
 
@@ -436,7 +436,7 @@ class Storage(storage.Storage):
 
 
     def __touch_fact(self, fact, end_time = None):
-        end_time = end_time or hamster_now()
+        end_time = end_time or dt.datetime.now()
         # tasks under one minute do not count
         if end_time - fact.start_time < dt.timedelta(minutes = 1):
             self.__remove_fact(fact.id)
@@ -510,7 +510,7 @@ class Storage(storage.Storage):
 
         for fact in conflicts:
             # fact is a sqlite.Row, indexable by column name
-            fact_end_time = fact["end_time"] or hamster_now()
+            fact_end_time = fact["end_time"] or dt.datetime.now()
 
             # won't eliminate as it is better to have overlapping entries than loosing data
             if start_time < fact["start_time"] and end_time > fact_end_time:
@@ -593,7 +593,7 @@ class Storage(storage.Storage):
             activity_id = activity_id['id']
 
         # if we are working on +/- current day - check the last_activity
-        if (dt.timedelta(days=-1) <= hamster_now() - start_time <= dt.timedelta(days=1)):
+        if (dt.timedelta(days=-1) <= dt.datetime.now() - start_time <= dt.timedelta(days=1)):
             # pull in previous facts
             facts = self.__get_todays_facts()
 

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -991,3 +991,25 @@ class Storage(storage.Storage):
             print("updated database from version %d to %d" % (version, current_version))
 
         self.end_transaction()
+
+
+# datetime/sql conversions
+
+DATETIME_LOCAL_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+def adapt_datetime(t):
+    """Convert datetime t to the suitable sql representation."""
+    return t.isoformat(" ")
+
+
+def convert_datetime(s):
+    """Convert the sql timestamp to datetime.
+
+    s is in bytes
+    """
+    return dt.datetime.strptime(s.decode('utf-8'), DATETIME_LOCAL_FMT)
+
+
+sqlite.register_adapter(dt.datetime, adapt_datetime)
+sqlite.register_converter("timestamp", convert_datetime)

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -37,7 +37,6 @@ except ImportError:
 from hamster.lib import datetime as dt
 from hamster.lib.configuration import conf
 from hamster.lib.fact import Fact
-from hamster.lib.stuff import hamster_today
 from hamster.storage import storage
 
 
@@ -674,7 +673,7 @@ class Storage(storage.Storage):
 
 
     def __get_todays_facts(self):
-        return self.__get_facts(hamster_today())
+        return self.__get_facts(dt.today())
 
     def __get_facts(self, date, end_date = None, search_terms = ""):
         split_time = conf.day_start

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -55,7 +55,7 @@ class Storage(object):
         if fact.end_time and (fact.delta < dt.timedelta(0)):
             fixed_fact = Fact(start_time=fact.start_time,
                               end_time=fact.end_time + dt.timedelta(days=1))
-            suggested_range_str = fixed_fact.serialized_range(default_day=default_day)
+            suggested_range_str = fixed_fact.range.format(default_day=default_day)
             # work around cyclic imports
             from hamster.lib.configuration import conf
             raise FactError(dedent(

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -21,9 +21,10 @@
 import logging
 logger = logging.getLogger(__name__)   # noqa: E402
 
-import datetime as dt
+from hamster.lib import datetime as dt
 from hamster.lib.fact import Fact, FactError
 from hamster.lib.stuff import hamster_now
+
 
 class Storage(object):
     def run_fixtures(self):

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -23,7 +23,6 @@ logger = logging.getLogger(__name__)   # noqa: E402
 
 from hamster.lib import datetime as dt
 from hamster.lib.fact import Fact, FactError
-from hamster.lib.stuff import hamster_now
 
 
 class Storage(object):

--- a/src/hamster/widgets/__init__.py
+++ b/src/hamster/widgets/__init__.py
@@ -17,11 +17,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
-import datetime as dt
 from gi.repository import Gtk as gtk
 from gi.repository import Gdk as gdk
 from gi.repository import Pango as pango
 
+from hamster.lib import datetime as dt
 # import our children
 from hamster.widgets.activityentry import (
     ActivityEntry,

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -27,8 +27,6 @@ import re
 from gi.repository import Gdk as gdk
 from gi.repository import Gtk as gtk
 from gi.repository import GObject as gobject
-import gi
-gi.require_version('PangoCairo', '1.0')
 from gi.repository import PangoCairo as pangocairo
 from gi.repository import Pango as pango
 from collections import defaultdict

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -290,7 +290,7 @@ class CmdLineEntry(gtk.Entry):
         self.todays_facts = self.storage.get_todays_facts()
 
         # list of facts of last month
-        now = stuff.hamster_now()
+        now = dt.datetime.now()
         last_month = self.storage.get_facts(now - dt.timedelta(days=30), now)
 
         # naive recency and frequency rank
@@ -356,7 +356,7 @@ class CmdLineEntry(gtk.Entry):
         res = []
 
         fact = Fact.parse(text)
-        now = stuff.hamster_now()
+        now = dt.datetime.now()
 
         # figure out what we are looking for
         # time -> activity[@category] -> tags -> description

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -22,7 +22,6 @@ logger = logging.getLogger(__name__)   # noqa: E402
 
 import bisect
 import cairo
-import datetime as dt
 import re
 
 from gi.repository import Gdk as gdk
@@ -36,6 +35,7 @@ from collections import defaultdict
 from copy import deepcopy
 
 from hamster import client
+from hamster.lib import datetime as dt
 from hamster.lib import stuff
 from hamster.lib import graphics
 from hamster.lib.configuration import runtime

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -427,7 +427,7 @@ class CmdLineEntry(gtk.Entry):
 
             prev_fact = self.todays_facts[-1] if self.todays_facts else None
             if prev_fact and prev_fact.end_time:
-                since = stuff.format_duration(now - prev_fact.end_time)
+                since = (now - prev_fact.end_time).format()
                 description = "from previous activity, %s ago" % since
                 variant = prev_fact.end_time.strftime("%H:%M ")
                 variants.append((description, variant))

--- a/src/hamster/widgets/dates.py
+++ b/src/hamster/widgets/dates.py
@@ -20,11 +20,11 @@
 from gi.repository import GObject as gobject
 from gi.repository import Gtk as gtk
 from gi.repository import Pango as pango
-import datetime as dt
+
 import calendar
 import re
 
-
+from hamster.lib import datetime as dt
 from hamster.lib import stuff
 from hamster.lib.configuration import load_ui_file
 

--- a/src/hamster/widgets/dayline.py
+++ b/src/hamster/widgets/dayline.py
@@ -24,7 +24,7 @@ from gi.repository import GObject as gobject
 from gi.repository import PangoCairo as pangocairo
 
 from hamster.lib import datetime as dt
-from hamster.lib import stuff, graphics, pytweener
+from hamster.lib import graphics, pytweener
 from hamster.lib.configuration import conf
 
 
@@ -92,7 +92,7 @@ class DayLine(graphics.Scene):
 
         self.day_start = conf.day_start
 
-        start_time = start_time or stuff.hamster_now()
+        start_time = start_time or dt.datetime.now()
 
         self.view_time = start_time or dt.datetime.combine(start_time.date(), self.day_start)
 
@@ -238,8 +238,8 @@ class DayLine(graphics.Scene):
                 pangocairo.show_layout(context, layout)
 
         #current time
-        if self.view_time < stuff.hamster_now() < self.view_time + dt.timedelta(hours = self.scope_hours):
-            minutes = round((stuff.hamster_now() - self.view_time).seconds / 60 / minute_pixel)
+        if self.view_time < dt.datetime.now() < self.view_time + dt.timedelta(hours = self.scope_hours):
+            minutes = round((dt.datetime.now() - self.view_time).seconds / 60 / minute_pixel)
             g.rectangle(minutes, 0, self.width, self.height)
             g.fill(colors['normal_bg'], 0.7)
 

--- a/src/hamster/widgets/dayline.py
+++ b/src/hamster/widgets/dayline.py
@@ -18,12 +18,12 @@
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import datetime as dt
 
 from gi.repository import Gtk as gtk
 from gi.repository import GObject as gobject
 from gi.repository import PangoCairo as pangocairo
 
+from hamster.lib import datetime as dt
 from hamster.lib import stuff, graphics, pytweener
 from hamster.lib.configuration import conf
 

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -477,7 +477,7 @@ class FactTree(graphics.Scene, gtk.Scrollable):
             start = self.facts[0].date
             end = self.facts[-1].date
         else:
-            start = end = dt.today()
+            start = end = dt.hday.today()
 
         by_date = defaultdict(list)
         for fact in self.facts:

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -233,7 +233,7 @@ class FactRow(object):
 
             g.restore_context()
 
-        self.duration_label.show(g, stuff.format_duration(self.fact.delta), x=self.width - 105)
+        self.duration_label.show(g, self.fact.delta.format(), x=self.width - 105)
 
         g.restore_context()
 

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -19,7 +19,6 @@
 
 import bisect
 import cairo
-import datetime as dt
 
 from collections import defaultdict
 from gi.repository import GObject as gobject
@@ -28,6 +27,7 @@ from gi.repository import Gdk as gdk
 from gi.repository import PangoCairo as pangocairo
 from gi.repository import Pango as pango
 
+from hamster.lib import datetime as dt
 from hamster.lib import graphics
 from hamster.lib import stuff
 

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -477,7 +477,7 @@ class FactTree(graphics.Scene, gtk.Scrollable):
             start = self.facts[0].date
             end = self.facts[-1].date
         else:
-            start = end = stuff.hamster_today()
+            start = end = dt.today()
 
         by_date = defaultdict(list)
         for fact in self.facts:

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -25,7 +25,7 @@ from gi.repository import Gtk as gtk
 from gi.repository import GObject as gobject
 
 from hamster.lib import datetime as dt
-from hamster.lib.stuff import format_duration, hamster_round
+from hamster.lib.stuff import hamster_round
 
 class TimeInput(gtk.Entry):
     __gsignals__ = {
@@ -221,7 +221,7 @@ class TimeInput(gtk.Entry):
         while i_time < end_time:
             row_text = self._format_time(i_time)
             if self.start_time is not None:
-                delta_text = format_duration(i_time - i_time_0)
+                delta_text = (i_time - i_time_0).format()
 
                 row_text += " (%s)" % delta_text
 

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
-import datetime as dt
 import calendar
 import re
 
@@ -25,6 +24,7 @@ from gi.repository import Gdk as gdk
 from gi.repository import Gtk as gtk
 from gi.repository import GObject as gobject
 
+from hamster.lib import datetime as dt
 from hamster.lib.stuff import format_duration, hamster_round
 
 class TimeInput(gtk.Entry):

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), "../
 import datetime as dt
 import unittest
 import re
+import hamster.lib.datetime as hdt
 from hamster.lib.fact import Fact
 from hamster.lib.stuff import (
     datetime_to_hamsterday,
@@ -255,6 +256,14 @@ class TestActivityInputParsing(unittest.TestCase):
                                     self.assertEqual(parsed.category, fact.category)
                                     self.assertEqual(parsed.description, fact.description)
                                     self.assertEqual(parsed.tags, fact.tags)
+
+
+class TestDatetime(unittest.TestCase):
+    def test_rounding(self):
+        dt1 = hdt.datetime(2019, 12, 31, hour=13, minute=14, second=10, microsecond=11)
+        self.assertEqual(dt1.second, 0)
+        self.assertEqual(dt1.microsecond, 0)
+        self.assertEqual(str(dt1), "2019-12-31 13:14")
 
 
 class TestParsers(unittest.TestCase):

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -8,7 +8,6 @@ import re
 from hamster.lib import datetime as hdt
 from hamster.lib.fact import Fact
 from hamster.lib.stuff import (
-    datetime_to_hamsterday,
     hamsterday_time_to_datetime,
     hamster_now,
     hamster_today,
@@ -16,13 +15,13 @@ from hamster.lib.stuff import (
 
 
 class TestActivityInputParsing(unittest.TestCase):
-    def test_datetime_to_hamsterday(self):
+    def test_get_day(self):
         date_time = dt.datetime(2018, 8, 13, 23, 10)  # 2018-08-13 23:10
         expected = dt.date(2018, 8, 13)
-        self.assertEqual(datetime_to_hamsterday(date_time), expected)
+        self.assertEqual(hdt.get_day(date_time), expected)
         date_time = dt.datetime(2018, 8, 14, 0, 10)  # 2018-08-14 0:10
         expected = dt.date(2018, 8, 13)
-        self.assertEqual(datetime_to_hamsterday(date_time), expected)
+        self.assertEqual(hdt.get_day(date_time), expected)
 
     def test_hamsterday_time_to_datetime(self):
         hamsterday = dt.date(2018, 8, 13)
@@ -359,14 +358,14 @@ class TestParsers(unittest.TestCase):
         (start, end), rest = hdt.Range.parse(s, ref=ref)
         just_before = start - hdt.timedelta(seconds=1)
         just_after = end + hdt.timedelta(seconds=1)
-        self.assertEqual(datetime_to_hamsterday(just_before), dt.date(2019, 12, 4))
-        self.assertEqual(datetime_to_hamsterday(just_after), dt.date(2019, 12, 6))
+        self.assertEqual(hdt.get_day(just_before), dt.date(2019, 12, 4))
+        self.assertEqual(hdt.get_day(just_after), dt.date(2019, 12, 6))
         s = "2019-12-05 2019-12-07"  # hamster days range
         (start, end), rest = hdt.Range.parse(s, ref=ref)
         just_before = start - hdt.timedelta(seconds=1)
         just_after = end + hdt.timedelta(seconds=1)
-        self.assertEqual(datetime_to_hamsterday(just_before), hdt.date(2019, 12, 4))
-        self.assertEqual(datetime_to_hamsterday(just_after), hdt.date(2019, 12, 8))
+        self.assertEqual(hdt.get_day(just_before), hdt.date(2019, 12, 4))
+        self.assertEqual(hdt.get_day(just_after), hdt.date(2019, 12, 8))
 
 
 if __name__ == '__main__':

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -14,8 +14,6 @@ from hamster.lib.stuff import (
     hamster_today,
     )
 from hamster.lib.parsing import (
-    dt_pattern,
-    _extract_datetime,
     parse_datetime_range,
     specific_dt_pattern,
     )
@@ -269,6 +267,9 @@ class TestDatetime(unittest.TestCase):
         self.assertEqual(hdt.time.parse("12.01"), dt.time(12, 1))
         self.assertEqual(hdt.time.parse("1201"), dt.time(12, 1))
 
+    def test_parse_datetime(self):
+        self.assertEqual(hdt.datetime.parse("2020-01-05 9:01"), dt.datetime(2020, 1, 5, 9, 1))
+
     def test_rounding(self):
         dt1 = hdt.datetime(2019, 12, 31, hour=13, minute=14, second=10, microsecond=11)
         self.assertEqual(dt1.second, 0)
@@ -281,18 +282,18 @@ class TestParsers(unittest.TestCase):
         p = specific_dt_pattern(1)
         s = "12:03"
         m = re.fullmatch(p, s, re.VERBOSE)
-        time = _extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
-                                default_day=hamster_today())
+        time = hdt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
+                                              default_day=hamster_today())
         self.assertEqual(time.strftime("%H:%M"), "12:03")
         s = "2019-12-01 12:36"
         m = re.fullmatch(p, s, re.VERBOSE)
-        time = _extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1")
+        time = hdt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1")
         self.assertEqual(time.strftime("%Y-%m-%d %H:%M"), "2019-12-01 12:36")
         s = "-25"
         m = re.fullmatch(p, s, re.VERBOSE)
-        timedelta = _extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
-                                     default_day=hamster_today())
-        self.assertEqual(timedelta, dt.timedelta(minutes=-25))
+        relative = hdt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
+                                                  default_day=hamster_today())
+        self.assertEqual(relative, dt.timedelta(minutes=-25))
         s = "2019-12-05"
         m = re.search(p, s, re.VERBOSE)
         self.assertEqual(m, None)

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -10,13 +10,6 @@ from hamster.lib.fact import Fact
 
 
 class TestActivityInputParsing(unittest.TestCase):
-    def test_get_day(self):
-        date_time = dt.datetime(2018, 8, 13, 23, 10)  # 2018-08-13 23:10
-        expected = dt.date(2018, 8, 13)
-        self.assertEqual(date_time.hday(), expected)
-        date_time = dt.datetime(2018, 8, 14, 0, 10)  # 2018-08-14 0:10
-        expected = dt.date(2018, 8, 13)
-        self.assertEqual(date_time.hday(), expected)
 
     def test_plain_name(self):
         # plain activity name
@@ -255,6 +248,13 @@ class TestDatetime(unittest.TestCase):
         delta = dt.timedelta(hours=5, minutes=10)
         self.assertEqual(delta.format("HH:MM"), "05:10")
 
+    def test_datetime_hday(self):
+        date_time = dt.datetime(2018, 8, 13, 23, 10)  # 2018-08-13 23:10
+        expected = dt.date(2018, 8, 13)
+        self.assertEqual(date_time.hday(), expected)
+        date_time = dt.datetime(2018, 8, 14, 0, 10)  # 2018-08-14 0:10
+        expected = dt.date(2018, 8, 13)
+        self.assertEqual(date_time.hday(), expected)
 
     def test_parse_date(self):
         date = dt.date.parse("2020-01-05")

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -270,37 +270,7 @@ class TestDatetime(unittest.TestCase):
     def test_parse_datetime(self):
         self.assertEqual(dt.datetime.parse("2020-01-05 9:01"), pdt.datetime(2020, 1, 5, 9, 1))
 
-    def test_rounding(self):
-        dt1 = dt.datetime(2019, 12, 31, hour=13, minute=14, second=10, microsecond=11)
-        self.assertEqual(dt1.second, 0)
-        self.assertEqual(dt1.microsecond, 0)
-        self.assertEqual(str(dt1), "2019-12-31 13:14")
-
-    def test_type_stability(self):
-        dt1 = dt.datetime(2020, 1, 10, hour=13, minute=30)
-        dt2 = dt.datetime(2020, 1, 10, hour=13, minute=40)
-        delta = dt2 - dt1
-        self.assertEqual(type(delta), dt.timedelta)
-        _sum = dt1 + delta
-        self.assertEqual(_sum, dt.datetime(2020, 1, 10, hour=13, minute=40))
-        self.assertEqual(type(_sum), dt.datetime)
-        _sub = dt1 - delta
-        self.assertEqual(_sub, dt.datetime(2020, 1, 10, hour=13, minute=20))
-        self.assertEqual(type(_sub), dt.datetime)
-
-        opposite = - delta
-        self.assertEqual(opposite, dt.timedelta(minutes=-10))
-        self.assertEqual(type(opposite), dt.timedelta)
-        _sum = delta + delta
-        self.assertEqual(_sum, dt.timedelta(minutes=20))
-        self.assertEqual(type(_sum), dt.timedelta)
-        _sub = delta - delta
-        self.assertEqual(_sub, dt.timedelta())
-        self.assertEqual(type(_sub), dt.timedelta)
-
-
-class TestParsers(unittest.TestCase):
-    def test_dt_patterns(self):
+    def test_datetime_patterns(self):
         p = dt.datetime.pattern(1)
         s = "12:03"
         m = re.fullmatch(p, s, re.VERBOSE)
@@ -319,7 +289,6 @@ class TestParsers(unittest.TestCase):
         s = "2019-12-05"
         m = re.search(p, s, re.VERBOSE)
         self.assertEqual(m, None)
-
 
     def test_parse_datetime_range(self):
         # only match clean
@@ -371,6 +340,34 @@ class TestParsers(unittest.TestCase):
         just_after = end + dt.timedelta(seconds=1)
         self.assertEqual(dt.get_day(just_before), dt.date(2019, 12, 4))
         self.assertEqual(dt.get_day(just_after), dt.date(2019, 12, 8))
+
+    def test_rounding(self):
+        dt1 = dt.datetime(2019, 12, 31, hour=13, minute=14, second=10, microsecond=11)
+        self.assertEqual(dt1.second, 0)
+        self.assertEqual(dt1.microsecond, 0)
+        self.assertEqual(str(dt1), "2019-12-31 13:14")
+
+    def test_type_stability(self):
+        dt1 = dt.datetime(2020, 1, 10, hour=13, minute=30)
+        dt2 = dt.datetime(2020, 1, 10, hour=13, minute=40)
+        delta = dt2 - dt1
+        self.assertEqual(type(delta), dt.timedelta)
+        _sum = dt1 + delta
+        self.assertEqual(_sum, dt.datetime(2020, 1, 10, hour=13, minute=40))
+        self.assertEqual(type(_sum), dt.datetime)
+        _sub = dt1 - delta
+        self.assertEqual(_sub, dt.datetime(2020, 1, 10, hour=13, minute=20))
+        self.assertEqual(type(_sub), dt.datetime)
+
+        opposite = - delta
+        self.assertEqual(opposite, dt.timedelta(minutes=-10))
+        self.assertEqual(type(opposite), dt.timedelta)
+        _sum = delta + delta
+        self.assertEqual(_sum, dt.timedelta(minutes=20))
+        self.assertEqual(type(_sum), dt.timedelta)
+        _sub = delta - delta
+        self.assertEqual(_sub, dt.timedelta())
+        self.assertEqual(type(_sub), dt.timedelta)
 
 
 if __name__ == '__main__':

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), "../
 import datetime as dt
 import unittest
 import re
-import hamster.lib.datetime as hdt
+from hamster.lib import datetime as hdt
 from hamster.lib.fact import Fact
 from hamster.lib.stuff import (
     datetime_to_hamsterday,
@@ -259,6 +259,10 @@ class TestActivityInputParsing(unittest.TestCase):
 
 
 class TestDatetime(unittest.TestCase):
+    def test_date(self):
+        date = hdt.date.parse("2020-01-05")
+        self.assertEqual(date, dt.date(2020, 1, 5))
+
     def test_rounding(self):
         dt1 = hdt.datetime(2019, 12, 31, hour=13, minute=14, second=10, microsecond=11)
         self.assertEqual(dt1.second, 0)

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -16,7 +16,6 @@ from hamster.lib.stuff import (
 from hamster.lib.parsing import (
     dt_pattern,
     _extract_datetime,
-    parse_time,
     parse_datetime_range,
     specific_dt_pattern,
     )
@@ -259,9 +258,16 @@ class TestActivityInputParsing(unittest.TestCase):
 
 
 class TestDatetime(unittest.TestCase):
-    def test_date(self):
+    def test_parse_date(self):
         date = hdt.date.parse("2020-01-05")
         self.assertEqual(date, dt.date(2020, 1, 5))
+
+    def test_parse_time(self):
+        self.assertEqual(hdt.time.parse("9:01"), dt.time(9, 1))
+        self.assertEqual(hdt.time.parse("9.01"), dt.time(9, 1))
+        self.assertEqual(hdt.time.parse("12:01"), dt.time(12, 1))
+        self.assertEqual(hdt.time.parse("12.01"), dt.time(12, 1))
+        self.assertEqual(hdt.time.parse("1201"), dt.time(12, 1))
 
     def test_rounding(self):
         dt1 = hdt.datetime(2019, 12, 31, hour=13, minute=14, second=10, microsecond=11)
@@ -271,13 +277,6 @@ class TestDatetime(unittest.TestCase):
 
 
 class TestParsers(unittest.TestCase):
-    def test_parse_time(self):
-        self.assertEqual(parse_time("9:01"), dt.time(9, 1))
-        self.assertEqual(parse_time("9.01"), dt.time(9, 1))
-        self.assertEqual(parse_time("12:01"), dt.time(12, 1))
-        self.assertEqual(parse_time("12.01"), dt.time(12, 1))
-        self.assertEqual(parse_time("1201"), dt.time(12, 1))
-
     def test_dt_patterns(self):
         p = specific_dt_pattern(1)
         s = "12:03"

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -298,49 +298,49 @@ class TestParsers(unittest.TestCase):
     def test_parse_datetime_range(self):
         # only match clean
         s = "10.00@cat"
-        start, end, rest = hdt.Range.parse(s, position="head")
+        (start, end), rest = hdt.Range.parse(s, position="head")
         self.assertEqual(start, None)
         self.assertEqual(end, None)
         s = "12:02"
-        start, end, rest = hdt.Range.parse(s)
+        (start, end), rest = hdt.Range.parse(s)
         self.assertEqual(start.strftime("%H:%M"), "12:02")
         self.assertEqual(end, None)
         s = "12:03 13:04"
-        start, end, rest = hdt.Range.parse(s)
+        (start, end), rest = hdt.Range.parse(s)
         self.assertEqual(start.strftime("%H:%M"), "12:03")
         self.assertEqual(end.strftime("%H:%M"), "13:04")
         s = "12:35 activity"
-        start, end, rest = hdt.Range.parse(s, position="head")
+        (start, end), rest = hdt.Range.parse(s, position="head")
         self.assertEqual(start.strftime("%H:%M"), "12:35")
         self.assertEqual(end, None)
         s = "2019-12-01 12:33 activity"
-        start, end, rest = hdt.Range.parse(s, position="head")
+        (start, end), rest = hdt.Range.parse(s, position="head")
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-12-01 12:33")
         self.assertEqual(end, None)
 
         ref = dt.datetime(2019, 11, 29, 13, 55)  # 2019-11-29 13:55
 
         s = "-25 activity"
-        start, end, rest = hdt.Range.parse(s, position="head", ref=ref)
+        (start, end), rest = hdt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:30")
         self.assertEqual(end, None)
         s = "-55 -25 activity"
-        start, end, rest = hdt.Range.parse(s, position="head", ref=ref)
+        (start, end), rest = hdt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:00")
         self.assertEqual(end.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:30")
         s = "-55 -120 activity"
-        start, end, rest = hdt.Range.parse(s, position="head", ref=ref)
+        (start, end), rest = hdt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:00")
         self.assertEqual(end.strftime("%Y-%m-%d %H:%M"), "2019-11-29 11:55")
 
         s = "2019-12-05"  # single hamster day
-        start, end, rest = hdt.Range.parse(s, ref=ref)
+        (start, end), rest = hdt.Range.parse(s, ref=ref)
         just_before = start - dt.timedelta(seconds=1)
         just_after = end + dt.timedelta(seconds=1)
         self.assertEqual(datetime_to_hamsterday(just_before), dt.date(2019, 12, 4))
         self.assertEqual(datetime_to_hamsterday(just_after), dt.date(2019, 12, 6))
         s = "2019-12-05 2019-12-07"  # hamster days range
-        start, end, rest = hdt.Range.parse(s, ref=ref)
+        (start, end), rest = hdt.Range.parse(s, ref=ref)
         just_before = start - dt.timedelta(seconds=1)
         just_after = end + dt.timedelta(seconds=1)
         self.assertEqual(datetime_to_hamsterday(just_before), dt.date(2019, 12, 4))

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -9,7 +9,25 @@ from hamster.lib import datetime as dt
 from hamster.lib.fact import Fact
 
 
-class TestActivityInputParsing(unittest.TestCase):
+class TestFact(unittest.TestCase):
+
+    def test_range(self):
+        t1 = dt.datetime(2020, 1, 15, 13, 30)
+        t2 = dt.datetime(2020, 1, 15, 15, 30)
+        range = dt.Range(t1, t2)
+        fact = Fact(range=range)
+        self.assertEqual(fact.range.start, t1)
+        self.assertEqual(fact.range.end, t2)
+        fact = Fact(start=t1, end=t2)
+        self.assertEqual(fact.range.start, t1)
+        self.assertEqual(fact.range.end, t2)
+        # backward compatibility (before v3.0)
+        fact = Fact(start_time=t1, end_time=t2)
+        self.assertEqual(fact.range.start, t1)
+        self.assertEqual(fact.range.end, t2)
+
+
+class TestFactParsing(unittest.TestCase):
 
     def test_plain_name(self):
         # plain activity name

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -9,7 +9,6 @@ from hamster.lib import datetime as dt
 from hamster.lib.fact import Fact
 from hamster.lib.stuff import (
     hamsterday_time_to_datetime,
-    hamster_today,
     )
 
 
@@ -223,10 +222,10 @@ class TestActivityInputParsing(unittest.TestCase):
                                 ["two", "tags"],
                                 ["with @at"],
                                 ):
-                                start = hamsterday_time_to_datetime(hamster_today(),
+                                start = hamsterday_time_to_datetime(dt.today(),
                                                                     start_time
                                                                     ) if start_time else None
-                                end = hamsterday_time_to_datetime(hamster_today(),
+                                end = hamsterday_time_to_datetime(dt.today(),
                                                                   end_time
                                                                   ) if end_time else None
                                 if end and not start:
@@ -298,7 +297,7 @@ class TestParsers(unittest.TestCase):
         s = "12:03"
         m = re.fullmatch(p, s, re.VERBOSE)
         time = dt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
-                                              default_day=hamster_today())
+                                              default_day=dt.today())
         self.assertEqual(time.strftime("%H:%M"), "12:03")
         s = "2019-12-01 12:36"
         m = re.fullmatch(p, s, re.VERBOSE)
@@ -307,7 +306,7 @@ class TestParsers(unittest.TestCase):
         s = "-25"
         m = re.fullmatch(p, s, re.VERBOSE)
         relative = dt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
-                                                  default_day=hamster_today())
+                                                  default_day=dt.today())
         self.assertEqual(relative, dt.timedelta(minutes=-25))
         s = "2019-12-05"
         m = re.search(p, s, re.VERBOSE)

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -9,7 +9,6 @@ from hamster.lib import datetime as dt
 from hamster.lib.fact import Fact
 from hamster.lib.stuff import (
     hamsterday_time_to_datetime,
-    hamster_now,
     hamster_today,
     )
 
@@ -135,10 +134,10 @@ class TestActivityInputParsing(unittest.TestCase):
         fact2.description = "abcd"
         self.assertNotEqual(fact1, fact2)
         fact2 = fact1.copy()
-        fact2.start_time = hamster_now()
+        fact2.start_time = dt.datetime.now()
         self.assertNotEqual(fact1, fact2)
         fact2 = fact1.copy()
-        fact2.end_time = hamster_now()
+        fact2.end_time = dt.datetime.now()
         self.assertNotEqual(fact1, fact2)
         # wrong order
         fact2 = fact1.copy()

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -209,10 +209,10 @@ class TestActivityInputParsing(unittest.TestCase):
                                 ["two", "tags"],
                                 ["with @at"],
                                 ):
-                                start = dt.datetime.from_day_time(dt.today(),
+                                start = dt.datetime.from_day_time(dt.hday.today(),
                                                                   start_time
                                                                   ) if start_time else None
-                                end = dt.datetime.from_day_time(dt.today(),
+                                end = dt.datetime.from_day_time(dt.hday.today(),
                                                                 end_time
                                                                 ) if end_time else None
                                 if end and not start:
@@ -275,7 +275,7 @@ class TestDatetime(unittest.TestCase):
         s = "12:03"
         m = re.fullmatch(p, s, re.VERBOSE)
         time = dt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
-                                              default_day=dt.today())
+                                              default_day=dt.hday.today())
         self.assertEqual(time.strftime("%H:%M"), "12:03")
         s = "2019-12-01 12:36"
         m = re.fullmatch(p, s, re.VERBOSE)
@@ -284,7 +284,7 @@ class TestDatetime(unittest.TestCase):
         s = "-25"
         m = re.fullmatch(p, s, re.VERBOSE)
         relative = dt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
-                                                  default_day=dt.today())
+                                                  default_day=dt.hday.today())
         self.assertEqual(relative, dt.timedelta(minutes=-25))
         s = "2019-12-05"
         m = re.search(p, s, re.VERBOSE)

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -13,9 +13,6 @@ from hamster.lib.stuff import (
     hamster_now,
     hamster_today,
     )
-from hamster.lib.parsing import (
-    parse_datetime_range,
-    )
 
 
 class TestActivityInputParsing(unittest.TestCase):
@@ -301,49 +298,49 @@ class TestParsers(unittest.TestCase):
     def test_parse_datetime_range(self):
         # only match clean
         s = "10.00@cat"
-        start, end, rest = parse_datetime_range(s, position="head")
+        start, end, rest = hdt.Range.parse(s, position="head")
         self.assertEqual(start, None)
         self.assertEqual(end, None)
         s = "12:02"
-        start, end, rest = parse_datetime_range(s)
+        start, end, rest = hdt.Range.parse(s)
         self.assertEqual(start.strftime("%H:%M"), "12:02")
         self.assertEqual(end, None)
         s = "12:03 13:04"
-        start, end, rest = parse_datetime_range(s)
+        start, end, rest = hdt.Range.parse(s)
         self.assertEqual(start.strftime("%H:%M"), "12:03")
         self.assertEqual(end.strftime("%H:%M"), "13:04")
         s = "12:35 activity"
-        start, end, rest = parse_datetime_range(s, position="head")
+        start, end, rest = hdt.Range.parse(s, position="head")
         self.assertEqual(start.strftime("%H:%M"), "12:35")
         self.assertEqual(end, None)
         s = "2019-12-01 12:33 activity"
-        start, end, rest = parse_datetime_range(s, position="head")
+        start, end, rest = hdt.Range.parse(s, position="head")
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-12-01 12:33")
         self.assertEqual(end, None)
 
         ref = dt.datetime(2019, 11, 29, 13, 55)  # 2019-11-29 13:55
 
         s = "-25 activity"
-        start, end, rest = parse_datetime_range(s, position="head", ref=ref)
+        start, end, rest = hdt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:30")
         self.assertEqual(end, None)
         s = "-55 -25 activity"
-        start, end, rest = parse_datetime_range(s, position="head", ref=ref)
+        start, end, rest = hdt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:00")
         self.assertEqual(end.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:30")
         s = "-55 -120 activity"
-        start, end, rest = parse_datetime_range(s, position="head", ref=ref)
+        start, end, rest = hdt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:00")
         self.assertEqual(end.strftime("%Y-%m-%d %H:%M"), "2019-11-29 11:55")
 
         s = "2019-12-05"  # single hamster day
-        start, end, rest = parse_datetime_range(s, ref=ref)
+        start, end, rest = hdt.Range.parse(s, ref=ref)
         just_before = start - dt.timedelta(seconds=1)
         just_after = end + dt.timedelta(seconds=1)
         self.assertEqual(datetime_to_hamsterday(just_before), dt.date(2019, 12, 4))
         self.assertEqual(datetime_to_hamsterday(just_after), dt.date(2019, 12, 6))
         s = "2019-12-05 2019-12-07"  # hamster days range
-        start, end, rest = parse_datetime_range(s, ref=ref)
+        start, end, rest = hdt.Range.parse(s, ref=ref)
         just_before = start - dt.timedelta(seconds=1)
         just_after = end + dt.timedelta(seconds=1)
         self.assertEqual(datetime_to_hamsterday(just_before), dt.date(2019, 12, 4))

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -15,7 +15,6 @@ from hamster.lib.stuff import (
     )
 from hamster.lib.parsing import (
     parse_datetime_range,
-    specific_dt_pattern,
     )
 
 
@@ -279,7 +278,7 @@ class TestDatetime(unittest.TestCase):
 
 class TestParsers(unittest.TestCase):
     def test_dt_patterns(self):
-        p = specific_dt_pattern(1)
+        p = hdt.datetime.pattern(1)
         s = "12:03"
         m = re.fullmatch(p, s, re.VERBOSE)
         time = hdt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -7,9 +7,6 @@ import unittest
 import re
 from hamster.lib import datetime as dt
 from hamster.lib.fact import Fact
-from hamster.lib.stuff import (
-    hamsterday_time_to_datetime,
-    )
 
 
 class TestActivityInputParsing(unittest.TestCase):
@@ -20,16 +17,6 @@ class TestActivityInputParsing(unittest.TestCase):
         date_time = dt.datetime(2018, 8, 14, 0, 10)  # 2018-08-14 0:10
         expected = dt.date(2018, 8, 13)
         self.assertEqual(dt.get_day(date_time), expected)
-
-    def test_hamsterday_time_to_datetime(self):
-        hamsterday = dt.date(2018, 8, 13)
-        time = dt.time(23, 10)
-        expected = dt.datetime(2018, 8, 13, 23, 10)  # 2018-08-13 23:10
-        self.assertEqual(hamsterday_time_to_datetime(hamsterday, time), expected)
-        hamsterday = dt.date(2018, 8, 13)
-        time = dt.time(0, 10)
-        expected = dt.datetime(2018, 8, 14, 0, 10)  # 2018-08-14 00:10
-        self.assertEqual(hamsterday_time_to_datetime(hamsterday, time), expected)
 
     def test_plain_name(self):
         # plain activity name
@@ -222,12 +209,12 @@ class TestActivityInputParsing(unittest.TestCase):
                                 ["two", "tags"],
                                 ["with @at"],
                                 ):
-                                start = hamsterday_time_to_datetime(dt.today(),
-                                                                    start_time
-                                                                    ) if start_time else None
-                                end = hamsterday_time_to_datetime(dt.today(),
-                                                                  end_time
-                                                                  ) if end_time else None
+                                start = dt.datetime.from_day_time(dt.today(),
+                                                                  start_time
+                                                                  ) if start_time else None
+                                end = dt.datetime.from_day_time(dt.today(),
+                                                                end_time
+                                                                ) if end_time else None
                                 if end and not start:
                                     # end without start is not parseable
                                     continue
@@ -248,6 +235,16 @@ class TestActivityInputParsing(unittest.TestCase):
 
 
 class TestDatetime(unittest.TestCase):
+    def test_datetime_from_day_time(self):
+        day = dt.date(2018, 8, 13)
+        time = dt.time(23, 10)
+        expected = dt.datetime(2018, 8, 13, 23, 10)  # 2018-08-13 23:10
+        self.assertEqual(dt.datetime.from_day_time(day, time), expected)
+        day = dt.date(2018, 8, 13)
+        time = dt.time(0, 10)
+        expected = dt.datetime(2018, 8, 14, 0, 10)  # 2018-08-14 00:10
+        self.assertEqual(dt.datetime.from_day_time(day, time), expected)
+
     def test_parse_date(self):
         date = dt.date.parse("2020-01-05")
         self.assertEqual(date, pdt.date(2020, 1, 5))

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -2,10 +2,10 @@ import sys, os.path
 # a convoluted line to add hamster module to absolute path
 sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), "../src")))
 
-import datetime as dt
+import datetime as pdt
 import unittest
 import re
-from hamster.lib import datetime as hdt
+from hamster.lib import datetime as dt
 from hamster.lib.fact import Fact
 from hamster.lib.stuff import (
     hamsterday_time_to_datetime,
@@ -18,10 +18,10 @@ class TestActivityInputParsing(unittest.TestCase):
     def test_get_day(self):
         date_time = dt.datetime(2018, 8, 13, 23, 10)  # 2018-08-13 23:10
         expected = dt.date(2018, 8, 13)
-        self.assertEqual(hdt.get_day(date_time), expected)
+        self.assertEqual(dt.get_day(date_time), expected)
         date_time = dt.datetime(2018, 8, 14, 0, 10)  # 2018-08-14 0:10
         expected = dt.date(2018, 8, 13)
-        self.assertEqual(hdt.get_day(date_time), expected)
+        self.assertEqual(dt.get_day(date_time), expected)
 
     def test_hamsterday_time_to_datetime(self):
         hamsterday = dt.date(2018, 8, 13)
@@ -134,7 +134,6 @@ class TestActivityInputParsing(unittest.TestCase):
         fact2 = fact1.copy()
         fact2.description = "abcd"
         self.assertNotEqual(fact1, fact2)
-        import datetime as dt
         fact2 = fact1.copy()
         fact2.start_time = hamster_now()
         self.assertNotEqual(fact1, fact2)
@@ -196,11 +195,11 @@ class TestActivityInputParsing(unittest.TestCase):
     def test_roundtrips(self):
         for start_time in (
             None,
-            hdt.time(12, 33),
+            dt.time(12, 33),
             ):
             for end_time in (
                 None,
-                hdt.time(13,34),
+                dt.time(13,34),
                 ):
                 for activity in (
                     "activity",
@@ -252,65 +251,65 @@ class TestActivityInputParsing(unittest.TestCase):
 
 class TestDatetime(unittest.TestCase):
     def test_parse_date(self):
-        date = hdt.date.parse("2020-01-05")
-        self.assertEqual(date, dt.date(2020, 1, 5))
+        date = dt.date.parse("2020-01-05")
+        self.assertEqual(date, pdt.date(2020, 1, 5))
 
     def test_parse_time(self):
-        self.assertEqual(hdt.time.parse("9:01"), dt.time(9, 1))
-        self.assertEqual(hdt.time.parse("9.01"), dt.time(9, 1))
-        self.assertEqual(hdt.time.parse("12:01"), dt.time(12, 1))
-        self.assertEqual(hdt.time.parse("12.01"), dt.time(12, 1))
-        self.assertEqual(hdt.time.parse("1201"), dt.time(12, 1))
+        self.assertEqual(dt.time.parse("9:01"), pdt.time(9, 1))
+        self.assertEqual(dt.time.parse("9.01"), pdt.time(9, 1))
+        self.assertEqual(dt.time.parse("12:01"), pdt.time(12, 1))
+        self.assertEqual(dt.time.parse("12.01"), pdt.time(12, 1))
+        self.assertEqual(dt.time.parse("1201"), pdt.time(12, 1))
 
     def test_parse_datetime(self):
-        self.assertEqual(hdt.datetime.parse("2020-01-05 9:01"), dt.datetime(2020, 1, 5, 9, 1))
+        self.assertEqual(dt.datetime.parse("2020-01-05 9:01"), pdt.datetime(2020, 1, 5, 9, 1))
 
     def test_rounding(self):
-        dt1 = hdt.datetime(2019, 12, 31, hour=13, minute=14, second=10, microsecond=11)
+        dt1 = dt.datetime(2019, 12, 31, hour=13, minute=14, second=10, microsecond=11)
         self.assertEqual(dt1.second, 0)
         self.assertEqual(dt1.microsecond, 0)
         self.assertEqual(str(dt1), "2019-12-31 13:14")
 
     def test_type_stability(self):
-        dt1 = hdt.datetime(2020, 1, 10, hour=13, minute=30)
-        dt2 = hdt.datetime(2020, 1, 10, hour=13, minute=40)
+        dt1 = dt.datetime(2020, 1, 10, hour=13, minute=30)
+        dt2 = dt.datetime(2020, 1, 10, hour=13, minute=40)
         delta = dt2 - dt1
-        self.assertEqual(type(delta), hdt.timedelta)
+        self.assertEqual(type(delta), dt.timedelta)
         _sum = dt1 + delta
-        self.assertEqual(_sum, hdt.datetime(2020, 1, 10, hour=13, minute=40))
-        self.assertEqual(type(_sum), hdt.datetime)
+        self.assertEqual(_sum, dt.datetime(2020, 1, 10, hour=13, minute=40))
+        self.assertEqual(type(_sum), dt.datetime)
         _sub = dt1 - delta
-        self.assertEqual(_sub, hdt.datetime(2020, 1, 10, hour=13, minute=20))
-        self.assertEqual(type(_sub), hdt.datetime)
+        self.assertEqual(_sub, dt.datetime(2020, 1, 10, hour=13, minute=20))
+        self.assertEqual(type(_sub), dt.datetime)
 
         opposite = - delta
-        self.assertEqual(opposite, hdt.timedelta(minutes=-10))
-        self.assertEqual(type(opposite), hdt.timedelta)
+        self.assertEqual(opposite, dt.timedelta(minutes=-10))
+        self.assertEqual(type(opposite), dt.timedelta)
         _sum = delta + delta
-        self.assertEqual(_sum, hdt.timedelta(minutes=20))
-        self.assertEqual(type(_sum), hdt.timedelta)
+        self.assertEqual(_sum, dt.timedelta(minutes=20))
+        self.assertEqual(type(_sum), dt.timedelta)
         _sub = delta - delta
-        self.assertEqual(_sub, hdt.timedelta())
-        self.assertEqual(type(_sub), hdt.timedelta)
+        self.assertEqual(_sub, dt.timedelta())
+        self.assertEqual(type(_sub), dt.timedelta)
 
 
 class TestParsers(unittest.TestCase):
     def test_dt_patterns(self):
-        p = hdt.datetime.pattern(1)
+        p = dt.datetime.pattern(1)
         s = "12:03"
         m = re.fullmatch(p, s, re.VERBOSE)
-        time = hdt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
+        time = dt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
                                               default_day=hamster_today())
         self.assertEqual(time.strftime("%H:%M"), "12:03")
         s = "2019-12-01 12:36"
         m = re.fullmatch(p, s, re.VERBOSE)
-        time = hdt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1")
+        time = dt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1")
         self.assertEqual(time.strftime("%Y-%m-%d %H:%M"), "2019-12-01 12:36")
         s = "-25"
         m = re.fullmatch(p, s, re.VERBOSE)
-        relative = hdt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
+        relative = dt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
                                                   default_day=hamster_today())
-        self.assertEqual(relative, hdt.timedelta(minutes=-25))
+        self.assertEqual(relative, dt.timedelta(minutes=-25))
         s = "2019-12-05"
         m = re.search(p, s, re.VERBOSE)
         self.assertEqual(m, None)
@@ -319,53 +318,53 @@ class TestParsers(unittest.TestCase):
     def test_parse_datetime_range(self):
         # only match clean
         s = "10.00@cat"
-        (start, end), rest = hdt.Range.parse(s, position="head")
+        (start, end), rest = dt.Range.parse(s, position="head")
         self.assertEqual(start, None)
         self.assertEqual(end, None)
         s = "12:02"
-        (start, end), rest = hdt.Range.parse(s)
+        (start, end), rest = dt.Range.parse(s)
         self.assertEqual(start.strftime("%H:%M"), "12:02")
         self.assertEqual(end, None)
         s = "12:03 13:04"
-        (start, end), rest = hdt.Range.parse(s)
+        (start, end), rest = dt.Range.parse(s)
         self.assertEqual(start.strftime("%H:%M"), "12:03")
         self.assertEqual(end.strftime("%H:%M"), "13:04")
         s = "12:35 activity"
-        (start, end), rest = hdt.Range.parse(s, position="head")
+        (start, end), rest = dt.Range.parse(s, position="head")
         self.assertEqual(start.strftime("%H:%M"), "12:35")
         self.assertEqual(end, None)
         s = "2019-12-01 12:33 activity"
-        (start, end), rest = hdt.Range.parse(s, position="head")
+        (start, end), rest = dt.Range.parse(s, position="head")
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-12-01 12:33")
         self.assertEqual(end, None)
 
-        ref = hdt.datetime(2019, 11, 29, 13, 55)  # 2019-11-29 13:55
+        ref = dt.datetime(2019, 11, 29, 13, 55)  # 2019-11-29 13:55
 
         s = "-25 activity"
-        (start, end), rest = hdt.Range.parse(s, position="head", ref=ref)
+        (start, end), rest = dt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:30")
         self.assertEqual(end, None)
         s = "-55 -25 activity"
-        (start, end), rest = hdt.Range.parse(s, position="head", ref=ref)
+        (start, end), rest = dt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:00")
         self.assertEqual(end.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:30")
         s = "-55 -120 activity"
-        (start, end), rest = hdt.Range.parse(s, position="head", ref=ref)
+        (start, end), rest = dt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:00")
         self.assertEqual(end.strftime("%Y-%m-%d %H:%M"), "2019-11-29 11:55")
 
         s = "2019-12-05"  # single hamster day
-        (start, end), rest = hdt.Range.parse(s, ref=ref)
-        just_before = start - hdt.timedelta(seconds=1)
-        just_after = end + hdt.timedelta(seconds=1)
-        self.assertEqual(hdt.get_day(just_before), dt.date(2019, 12, 4))
-        self.assertEqual(hdt.get_day(just_after), dt.date(2019, 12, 6))
+        (start, end), rest = dt.Range.parse(s, ref=ref)
+        just_before = start - dt.timedelta(seconds=1)
+        just_after = end + dt.timedelta(seconds=1)
+        self.assertEqual(dt.get_day(just_before), pdt.date(2019, 12, 4))
+        self.assertEqual(dt.get_day(just_after), pdt.date(2019, 12, 6))
         s = "2019-12-05 2019-12-07"  # hamster days range
-        (start, end), rest = hdt.Range.parse(s, ref=ref)
-        just_before = start - hdt.timedelta(seconds=1)
-        just_after = end + hdt.timedelta(seconds=1)
-        self.assertEqual(hdt.get_day(just_before), hdt.date(2019, 12, 4))
-        self.assertEqual(hdt.get_day(just_after), hdt.date(2019, 12, 8))
+        (start, end), rest = dt.Range.parse(s, ref=ref)
+        just_before = start - dt.timedelta(seconds=1)
+        just_after = end + dt.timedelta(seconds=1)
+        self.assertEqual(dt.get_day(just_before), dt.date(2019, 12, 4))
+        self.assertEqual(dt.get_day(just_after), dt.date(2019, 12, 8))
 
 
 if __name__ == '__main__':

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -197,11 +197,11 @@ class TestActivityInputParsing(unittest.TestCase):
     def test_roundtrips(self):
         for start_time in (
             None,
-            dt.time(12, 33),
+            hdt.time(12, 33),
             ):
             for end_time in (
                 None,
-                dt.time(13,34),
+                hdt.time(13,34),
                 ):
                 for activity in (
                     "activity",
@@ -272,6 +272,28 @@ class TestDatetime(unittest.TestCase):
         self.assertEqual(dt1.microsecond, 0)
         self.assertEqual(str(dt1), "2019-12-31 13:14")
 
+    def test_type_stability(self):
+        dt1 = hdt.datetime(2020, 1, 10, hour=13, minute=30)
+        dt2 = hdt.datetime(2020, 1, 10, hour=13, minute=40)
+        delta = dt2 - dt1
+        self.assertEqual(type(delta), hdt.timedelta)
+        _sum = dt1 + delta
+        self.assertEqual(_sum, hdt.datetime(2020, 1, 10, hour=13, minute=40))
+        self.assertEqual(type(_sum), hdt.datetime)
+        _sub = dt1 - delta
+        self.assertEqual(_sub, hdt.datetime(2020, 1, 10, hour=13, minute=20))
+        self.assertEqual(type(_sub), hdt.datetime)
+
+        opposite = - delta
+        self.assertEqual(opposite, hdt.timedelta(minutes=-10))
+        self.assertEqual(type(opposite), hdt.timedelta)
+        _sum = delta + delta
+        self.assertEqual(_sum, hdt.timedelta(minutes=20))
+        self.assertEqual(type(_sum), hdt.timedelta)
+        _sub = delta - delta
+        self.assertEqual(_sub, hdt.timedelta())
+        self.assertEqual(type(_sub), hdt.timedelta)
+
 
 class TestParsers(unittest.TestCase):
     def test_dt_patterns(self):
@@ -289,7 +311,7 @@ class TestParsers(unittest.TestCase):
         m = re.fullmatch(p, s, re.VERBOSE)
         relative = hdt.datetime._extract_datetime(m, d="date1", h="hour1", m="minute1", r="relative1",
                                                   default_day=hamster_today())
-        self.assertEqual(relative, dt.timedelta(minutes=-25))
+        self.assertEqual(relative, hdt.timedelta(minutes=-25))
         s = "2019-12-05"
         m = re.search(p, s, re.VERBOSE)
         self.assertEqual(m, None)
@@ -318,7 +340,7 @@ class TestParsers(unittest.TestCase):
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-12-01 12:33")
         self.assertEqual(end, None)
 
-        ref = dt.datetime(2019, 11, 29, 13, 55)  # 2019-11-29 13:55
+        ref = hdt.datetime(2019, 11, 29, 13, 55)  # 2019-11-29 13:55
 
         s = "-25 activity"
         (start, end), rest = hdt.Range.parse(s, position="head", ref=ref)
@@ -335,16 +357,16 @@ class TestParsers(unittest.TestCase):
 
         s = "2019-12-05"  # single hamster day
         (start, end), rest = hdt.Range.parse(s, ref=ref)
-        just_before = start - dt.timedelta(seconds=1)
-        just_after = end + dt.timedelta(seconds=1)
+        just_before = start - hdt.timedelta(seconds=1)
+        just_after = end + hdt.timedelta(seconds=1)
         self.assertEqual(datetime_to_hamsterday(just_before), dt.date(2019, 12, 4))
         self.assertEqual(datetime_to_hamsterday(just_after), dt.date(2019, 12, 6))
         s = "2019-12-05 2019-12-07"  # hamster days range
         (start, end), rest = hdt.Range.parse(s, ref=ref)
-        just_before = start - dt.timedelta(seconds=1)
-        just_after = end + dt.timedelta(seconds=1)
-        self.assertEqual(datetime_to_hamsterday(just_before), dt.date(2019, 12, 4))
-        self.assertEqual(datetime_to_hamsterday(just_after), dt.date(2019, 12, 8))
+        just_before = start - hdt.timedelta(seconds=1)
+        just_after = end + hdt.timedelta(seconds=1)
+        self.assertEqual(datetime_to_hamsterday(just_before), hdt.date(2019, 12, 4))
+        self.assertEqual(datetime_to_hamsterday(just_after), hdt.date(2019, 12, 8))
 
 
 if __name__ == '__main__':

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -245,6 +245,17 @@ class TestDatetime(unittest.TestCase):
         expected = dt.datetime(2018, 8, 14, 0, 10)  # 2018-08-14 00:10
         self.assertEqual(dt.datetime.from_day_time(day, time), expected)
 
+    def test_format_timedelta(self):
+        delta = dt.timedelta(minutes=10)
+        self.assertEqual(delta.format("human"), "10min")
+        delta = dt.timedelta(hours=5, minutes=0)
+        self.assertEqual(delta.format("human"), "5h")
+        delta = dt.timedelta(hours=5, minutes=10)
+        self.assertEqual(delta.format("human"), "5h 10min")
+        delta = dt.timedelta(hours=5, minutes=10)
+        self.assertEqual(delta.format("HH:MM"), "05:10")
+
+
     def test_parse_date(self):
         date = dt.date.parse("2020-01-05")
         self.assertEqual(date, pdt.date(2020, 1, 5))

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -13,10 +13,10 @@ class TestActivityInputParsing(unittest.TestCase):
     def test_get_day(self):
         date_time = dt.datetime(2018, 8, 13, 23, 10)  # 2018-08-13 23:10
         expected = dt.date(2018, 8, 13)
-        self.assertEqual(dt.get_day(date_time), expected)
+        self.assertEqual(date_time.hday(), expected)
         date_time = dt.datetime(2018, 8, 14, 0, 10)  # 2018-08-14 0:10
         expected = dt.date(2018, 8, 13)
-        self.assertEqual(dt.get_day(date_time), expected)
+        self.assertEqual(date_time.hday(), expected)
 
     def test_plain_name(self):
         # plain activity name
@@ -332,14 +332,14 @@ class TestDatetime(unittest.TestCase):
         (start, end), rest = dt.Range.parse(s, ref=ref)
         just_before = start - dt.timedelta(seconds=1)
         just_after = end + dt.timedelta(seconds=1)
-        self.assertEqual(dt.get_day(just_before), pdt.date(2019, 12, 4))
-        self.assertEqual(dt.get_day(just_after), pdt.date(2019, 12, 6))
+        self.assertEqual(just_before.hday(), pdt.date(2019, 12, 4))
+        self.assertEqual(just_after.hday(), pdt.date(2019, 12, 6))
         s = "2019-12-05 2019-12-07"  # hamster days range
         (start, end), rest = dt.Range.parse(s, ref=ref)
         just_before = start - dt.timedelta(seconds=1)
         just_after = end + dt.timedelta(seconds=1)
-        self.assertEqual(dt.get_day(just_before), dt.date(2019, 12, 4))
-        self.assertEqual(dt.get_day(just_after), dt.date(2019, 12, 8))
+        self.assertEqual(just_before.hday(), dt.date(2019, 12, 4))
+        self.assertEqual(just_after.hday(), dt.date(2019, 12, 8))
 
     def test_rounding(self):
         dt1 = dt.datetime(2019, 12, 31, hour=13, minute=14, second=10, microsecond=11)


### PR DESCRIPTION
Introduce `hamster/lib/datetime.py`.
This is the first step towards fixing #166.
For now times are still "naive", 
but this PR should allow us to smoothly shift to "timezone-aware" later on.
We also now have full control on the python/sql conversions
(does not change anything yet, but creates opportunities).

Bonus: code seems a bit clearer with parsers close to their objects.
The ephemeral `parsing.py` will soon be removed.

Some `stuff.py` code was transferred to the new `datetime.py`, but compatibility is retained for a while.
Transfer can be finished later.