### PR TITLE
json verbatim

### DIFF
--- a/src/hamster-service.py
+++ b/src/hamster-service.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # nicked off gwibber
 
+import dbus
+import dbus.service
+
 from gi.repository import GLib as glib
 from gi.repository import Gio as gio
 
@@ -13,11 +16,13 @@ from hamster.lib import datetime as dt
 from hamster.lib import default_logger
 from hamster.lib.dbus import (
     DBusMainLoop,
-    dbus,
     fact_signature,
     from_dbus_date,
     from_dbus_fact,
-    to_dbus_fact
+    from_dbus_fact_json,
+    from_dbus_range,
+    to_dbus_fact,
+    to_dbus_fact_json
 )
 from hamster.lib.fact import Fact, FactError
 
@@ -166,17 +171,17 @@ class Storage(db.Storage, dbus.service.Object):
         return self.add_fact(fact) or 0
 
 
-    @dbus.service.method("org.gnome.Hamster", in_signature=fact_signature, out_signature='i')
-    def AddFactVerbatim(self, dbus_fact):
-        fact = from_dbus_fact(dbus_fact)
+    @dbus.service.method("org.gnome.Hamster", in_signature='s', out_signature='i')
+    def AddFactJSON(self, dbus_fact):
+        fact = from_dbus_fact_json(dbus_fact)
         return self.add_fact(fact) or 0
 
 
     @dbus.service.method("org.gnome.Hamster",
-                         in_signature="{}i".format(fact_signature),
+                         in_signature="si",
                          out_signature='bs')
     def CheckFact(self, dbus_fact, dbus_default_day):
-        fact = from_dbus_fact(dbus_fact)
+        fact = from_dbus_fact_json(dbus_fact)
         dd = from_dbus_date(dbus_default_day)
         try:
             self.check_fact(fact, default_day=dd)
@@ -197,6 +202,15 @@ class Storage(db.Storage, dbus.service.Object):
         return to_dbus_fact(fact)
 
 
+    @dbus.service.method("org.gnome.Hamster",
+                         in_signature='i',
+                         out_signature="s")
+    def GetFactJSON(self, fact_id):
+        """Get fact by id. For output format see GetFacts"""
+        fact = self.get_fact(fact_id)
+        return to_dbus_fact_json(fact)
+
+
     @dbus.service.method("org.gnome.Hamster", in_signature='isiib', out_signature='i')
     def UpdateFact(self, fact_id, fact, start_time, end_time, temporary = False):
         start_time = start_time or None
@@ -210,10 +224,10 @@ class Storage(db.Storage, dbus.service.Object):
 
 
     @dbus.service.method("org.gnome.Hamster",
-                         in_signature='i{}'.format(fact_signature),
+                         in_signature='is',
                          out_signature='i')
-    def UpdateFactVerbatim(self, fact_id, dbus_fact):
-        fact = from_dbus_fact(dbus_fact)
+    def UpdateFactJSON(self, fact_id, dbus_fact):
+        fact = from_dbus_fact_json(dbus_fact)
         return self.update_fact(fact_id, fact) or 0
 
 
@@ -242,6 +256,8 @@ class Storage(db.Storage, dbus.service.Object):
         i end_date: Seconds since epoch (timestamp). Use 0 for today
         s search_terms: Bleh. If starts with "not ", the search terms will be reversed
         Returns an array of D-Bus fact structures.
+
+        Legacy. To be superceded by GetFactsJSON at some point.
         """
         #TODO: Assert start > end ?
         start = dt.date.today()
@@ -255,11 +271,48 @@ class Storage(db.Storage, dbus.service.Object):
         return [to_dbus_fact(fact) for fact in self.get_facts(start, end, search_terms)]
 
 
+    @dbus.service.method("org.gnome.Hamster",
+                         in_signature='ss',
+                         out_signature='as')
+    def GetFactsJSON(self, dbus_range, search_terms):
+        """Gets facts between the day of start and the day of end.
+        Parameters:
+        s range: range string, same format as on the command line.
+        s search_terms: Bleh. If starts with "not ", the search terms will be reversed
+        Returns an array of D-Bus facts in JSON format.
+
+        Note: Currently, only whole hamster days (that might evolve).
+        This will be the preferred way to get facts.
+        """
+
+        range = from_dbus_range(dbus_range)
+        start_dt = range.start if range.start else dt.hday.today().start
+        end_dt = range.end if range.end else dt.hday.today().end
+
+        start_d = start_dt.date()
+        end_d = end_dt.date()
+
+        return [to_dbus_fact_json(fact)
+                for fact in self.get_facts(start_d, end_d, search_terms)]
+
+
     @dbus.service.method("org.gnome.Hamster", out_signature='a{}'.format(fact_signature))
     def GetTodaysFacts(self):
-        """Gets facts of today, respecting hamster midnight. See GetFacts for
-        return info"""
+        """Gets facts of today,
+           respecting hamster midnight. See GetFacts for return info.
+
+           Legacy, to be superceded by GetTodaysFactsJSON at some point.
+        """
         return [to_dbus_fact(fact) for fact in self.get_todays_facts()]
+
+
+    @dbus.service.method("org.gnome.Hamster", out_signature='as')
+    def GetTodaysFactsJSON(self):
+        """Gets facts of the current hamster day.
+
+        Return an array of facts in JSON format.
+        """
+        return [to_dbus_fact_json(fact) for fact in self.get_todays_facts()]
 
 
     # categories

--- a/src/hamster-service.py
+++ b/src/hamster-service.py
@@ -284,16 +284,9 @@ class Storage(db.Storage, dbus.service.Object):
         Note: Currently, only whole hamster days (that might evolve).
         This will be the preferred way to get facts.
         """
-
         range = from_dbus_range(dbus_range)
-        start_dt = range.start if range.start else dt.hday.today().start
-        end_dt = range.end if range.end else dt.hday.today().end
-
-        start_d = start_dt.date()
-        end_d = end_dt.date()
-
         return [to_dbus_fact_json(fact)
-                for fact in self.get_facts(start_d, end_d, search_terms)]
+                for fact in self.get_facts(range, search_terms=search_terms)]
 
 
     @dbus.service.method("org.gnome.Hamster", out_signature='a{}'.format(fact_signature))

--- a/src/hamster-service.py
+++ b/src/hamster-service.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 # nicked off gwibber
 
-import logging
 from gi.repository import GLib as glib
 from gi.repository import Gio as gio
 
 from hamster import logger as hamster_logger
 from hamster.lib import i18n
-i18n.setup_i18n()
+i18n.setup_i18n()  # noqa: E402
 
 from hamster.storage import db
 from hamster.lib import datetime as dt

--- a/src/hamster-service.py
+++ b/src/hamster-service.py
@@ -173,6 +173,19 @@ class Storage(db.Storage, dbus.service.Object):
 
     @dbus.service.method("org.gnome.Hamster", in_signature='s', out_signature='i')
     def AddFactJSON(self, dbus_fact):
+        """Add fact given in JSON format.
+
+        This is the preferred method if the fact fields are known separately,
+        as activity, category, description and tags are passed "verbatim".
+        Only datetimes are interpreted
+        (2020-01-20: JSON does not know datetimes).
+
+        Args:
+            dbus_fact (str): fact in JSON format (cf. from_dbus_fact_json).
+
+        Returns:
+            fact id (int), or 0 in case of failure.
+        """
         fact = from_dbus_fact_json(dbus_fact)
         return self.add_fact(fact) or 0
 
@@ -181,6 +194,19 @@ class Storage(db.Storage, dbus.service.Object):
                          in_signature="si",
                          out_signature='bs')
     def CheckFact(self, dbus_fact, dbus_default_day):
+        """Check fact validity.
+
+        Useful to determine in advance whether the fact
+        can be included in the database.
+
+        Args:
+            dbus_fact (str): fact in JSON format (cf. AddFactJSON)
+
+        Returns:
+            success (boolean): True upon success.
+            message (str): what's wrong.
+        """
+
         fact = from_dbus_fact_json(dbus_fact)
         dd = from_dbus_date(dbus_default_day)
         try:
@@ -206,7 +232,10 @@ class Storage(db.Storage, dbus.service.Object):
                          in_signature='i',
                          out_signature="s")
     def GetFactJSON(self, fact_id):
-        """Get fact by id. For output format see GetFacts"""
+        """Get fact by id.
+
+        Return fact in JSON format (cf. to_dbus_fact_json)
+        """
         fact = self.get_fact(fact_id)
         return to_dbus_fact_json(fact)
 
@@ -227,6 +256,14 @@ class Storage(db.Storage, dbus.service.Object):
                          in_signature='is',
                          out_signature='i')
     def UpdateFactJSON(self, fact_id, dbus_fact):
+        """Update fact.
+
+        Args:
+            fact_id (int): fact id in the database.
+            dbus_fact (str): new fact content, in JSON format.
+        Returns:
+            int: new id (0 means failure)
+        """
         fact = from_dbus_fact_json(dbus_fact)
         return self.update_fact(fact_id, fact) or 0
 
@@ -276,12 +313,16 @@ class Storage(db.Storage, dbus.service.Object):
                          out_signature='as')
     def GetFactsJSON(self, dbus_range, search_terms):
         """Gets facts between the day of start and the day of end.
-        Parameters:
-        s range: range string, same format as on the command line.
-        s search_terms: Bleh. If starts with "not ", the search terms will be reversed
-        Returns an array of D-Bus facts in JSON format.
 
-        Note: Currently, only whole hamster days (that might evolve).
+        Args:
+            dbus_range (str): same format as on the command line.
+                              (cf. dt.Range.parse)
+            search_terms (str): If starts with "not ",
+                                the search terms will be reversed
+        Return:
+            array of D-Bus facts in JSON format.
+            (cf. to_dbus_fact_json)
+
         This will be the preferred way to get facts.
         """
         range = from_dbus_range(dbus_range)

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -115,17 +115,7 @@ class Storage(gobject.GObject):
            to boolean AND.
            Filter is applied to tags, categories, activity names and description
         """
-        # transition from legacy
-        if isinstance(start, dt.pdt.date):
-            start = dt.hday.from_pdt(start).start
-        elif isinstance(start, dt.hday):
-            start = start.start
-        if isinstance(end, dt.pdt.date):
-            end = dt.hday.from_pdt(end).end
-        elif isinstance(end, dt.hday):
-            end = end.end
-
-        range = dt.Range(start=start, end=end)
+        range = dt.Range.from_start_end(start, end)
         dbus_range = to_dbus_range(range)
         return [from_dbus_fact_json(fact)
                 for fact in self.conn.GetFactsJSON(dbus_range, search_terms)]

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -19,17 +19,20 @@
 # along with Project Hamster.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import dbus
 import logging
 logger = logging.getLogger(__name__)   # noqa: E402
 
 from calendar import timegm
 from gi.repository import GObject as gobject
+
 from hamster.lib.dbus import (
     DBusMainLoop,
-    dbus,
-    from_dbus_fact,
+    from_dbus_fact_json,
     to_dbus_date,
     to_dbus_fact,
+    to_dbus_fact_json,
+    to_dbus_range,
     )
 from hamster.lib.fact import Fact, FactError
 from hamster.lib import datetime as dt
@@ -104,21 +107,28 @@ class Storage(gobject.GObject):
         """returns facts of the current date, respecting hamster midnight
            hamster midnight is stored in gconf, and presented in minutes
         """
-        return [from_dbus_fact(fact) for fact in self.conn.GetTodaysFacts()]
+        return [from_dbus_fact_json(fact) for fact in self.conn.GetTodaysFactsJSON()]
 
-    def get_facts(self, date, end_date=None, search_terms=""):
+    def get_facts(self, start, end=None, search_terms=""):
         """Returns facts for the time span matching the optional filter criteria.
            In search terms comma (",") translates to boolean OR and space (" ")
            to boolean AND.
            Filter is applied to tags, categories, activity names and description
         """
-        date = timegm(date.timetuple())
-        end_date = end_date or 0
-        if end_date:
-            end_date = timegm(end_date.timetuple())
-        return [from_dbus_fact(fact) for fact in self.conn.GetFacts(date,
-                                                                    end_date,
-                                                                    search_terms)]
+        # transition from legacy
+        if isinstance(start, dt.pdt.date):
+            start = dt.hday.from_pdt(start).start
+        elif isinstance(start, dt.hday):
+            start = start.start
+        if isinstance(end, dt.pdt.date):
+            end = dt.hday.from_pdt(end).end
+        elif isinstance(end, dt.hday):
+            end = end.end
+
+        range = dt.Range(start=start, end=end)
+        dbus_range = to_dbus_range(range)
+        return [from_dbus_fact_json(fact)
+                for fact in self.conn.GetFactsJSON(dbus_range, search_terms)]
 
     def get_activities(self, search = ""):
         """returns list of activities name matching search criteria.
@@ -152,7 +162,7 @@ class Storage(gobject.GObject):
 
     def get_fact(self, id):
         """returns fact by it's ID"""
-        return from_dbus_fact(self.conn.GetFact(id))
+        return from_dbus_fact_json(self.conn.GetFactJSON(id))
 
     def check_fact(self, fact, default_day=None):
         """Check Fact validity for inclusion in the storage.
@@ -166,7 +176,7 @@ class Storage(gobject.GObject):
             # Do not even try to pass fact through D-Bus as
             # conversions would fail in this case.
             raise FactError("Missing start time")
-        dbus_fact = to_dbus_fact(fact)
+        dbus_fact = to_dbus_fact_json(fact)
         dbus_day = to_dbus_date(default_day)
         success, message = self.conn.CheckFact(dbus_fact, dbus_day)
         if not success:
@@ -181,8 +191,8 @@ class Storage(gobject.GObject):
             logger.info("Adding fact without any start_time is deprecated")
             fact.start_time = dt.datetime.now()
 
-        dbus_fact = to_dbus_fact(fact)
-        new_id = self.conn.AddFactVerbatim(dbus_fact)
+        dbus_fact = to_dbus_fact_json(fact)
+        new_id = self.conn.AddFactJSON(dbus_fact)
 
         return new_id
 
@@ -202,8 +212,8 @@ class Storage(gobject.GObject):
         fact_id after update should not be used anymore. Instead use the ID
         from the fact dict that is returned by this function"""
 
-        dbus_fact = to_dbus_fact(fact)
-        new_id =  self.conn.UpdateFactVerbatim(fact_id, dbus_fact)
+        dbus_fact = to_dbus_fact_json(fact)
+        new_id = self.conn.UpdateFactJSON(fact_id, dbus_fact)
 
         return new_id
 

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -543,6 +543,40 @@ class Range():
             """.format(datetime.pattern(1), date.pattern(detailed=False),
                        datetime.pattern(2), date.pattern(detailed=False)))
 
+    @classmethod
+    def from_start_end(cls, start, end=None):
+        """Return a Range from separate arguments.
+
+        Convenient to ease backward compatibility,
+        and to handle either hdays or datetimes.
+        """
+        if isinstance(start, Range):
+            assert end is None, "range and end are mutually exclusive"
+            range = start
+        else:
+            if isinstance(start, hday):
+                day = start
+                start = day.start
+                if end is None:
+                    end = day.end
+            elif isinstance(start, pdt.date):
+                # transition from legacy
+                start = hday.from_pdt(start).start
+
+            if isinstance(end, hday):
+                end = end.end
+            elif isinstance(end, pdt.date):
+                end = hday.from_pdt(end).end
+
+            range = Range(start, end)
+
+        return range
+
+    @classmethod
+    def today(cls):
+        _today = hday.today()
+        return cls(_today.start, _today.end)
+
 
 class timedelta(pdt.timedelta):
     """Hamster timedelta.

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -68,6 +68,10 @@ class date(pdt.date):
         else:
             return r"""\d{4}-\d{2}-\d{2}"""
 
+    @classmethod
+    def from_pdt(cls, d):
+        """Convert python date to hamster date."""
+        return cls(d.year, d.month, d.day)
 
 # For datetime that will need to be outside the class.
 # Same here for consistency
@@ -386,6 +390,12 @@ class Range():
     def __init__(self, start=None, end=None):
         self.start = start
         self.end = end
+
+    def __eq__(self, other):
+        if isinstance(other, Range):
+            return self.start == other.start and self.end == other.end
+        else:
+            return False
 
     # allow start, end = range
     def __iter__(self):

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -302,6 +302,8 @@ class datetime(pdt.datetime):
             civil_date = d
         return cls.combine(civil_date, t)
 
+    # Note: fromisoformat appears in python3.7
+
     @classmethod
     def from_pdt(cls, t):
         """Convert python datetime to hamster datetime."""

--- a/src/hamster/lib/dbus.py
+++ b/src/hamster/lib/dbus.py
@@ -1,12 +1,18 @@
 import dbus
-import dbus.service
-from calendar import timegm
+
 from dbus.mainloop.glib import DBusGMainLoop as DBusMainLoop
+from json import dumps, loads
+from calendar import timegm
 from hamster.lib import datetime as dt
 from hamster.lib.fact import Fact
 
 
 """D-Bus communication utilities."""
+
+# file layout: functions sorted in alphabetical order,
+# not taking into account the "to_" and "from_" prefixes.
+# So back and forth conversions are close to one another.
+
 
 # dates
 
@@ -22,8 +28,53 @@ def to_dbus_date(date):
 
 # facts
 
+def from_dbus_fact_json(dbus_fact):
+    """Convert D-Bus JSON to Fact."""
+    d = loads(dbus_fact)
+    range_d = d['range']
+    # should use pdt.datetime.fromisoformat,
+    # but that appears only in python3.7, nevermind
+    start_s = range_d['start']
+    end_s = range_d['end']
+    range = dt.Range(start=dt.datetime.parse(start_s) if start_s else None,
+                     end=dt.datetime.parse(end_s) if end_s else None)
+    d['range'] = range
+    return Fact(**d)
+
+
+def to_dbus_fact_json(fact):
+    """Convert Fact to D-Bus JSON (str)."""
+    d = {}
+    keys = ('activity', 'category', 'description', 'tags', 'id', 'activity_id')
+    for key in keys:
+        d[key] = getattr(fact, key)
+    # isoformat(timespec="minutes") appears only in python3.6, nevermind
+    # and fromisoformat is not available anyway, so let's talk hamster
+    start = str(fact.range.start) if fact.range.start else None
+    end = str(fact.range.end) if fact.range.end else None
+    d['range'] = {'start': start, 'end': end}
+    return dumps(d)
+
+
+# Range
+
+def from_dbus_range(dbus_range):
+    """Convert from D-Bus string to dt.Range."""
+    range, __ = dt.Range.parse(dbus_range, position="exact")
+    return range
+
+
+def to_dbus_range(range):
+    """Convert dt.Range to D-Bus string."""
+
+    # no default_day, to always output in the same format
+    return range.format(default_day=None)
+
+
+# Legacy functions:
+
 """
-dbus_fact signature (types matching the to_dbus_fact output)
+old dbus_fact signature (types matching the to_dbus_fact output)
     i  id
     i  start_time
     i  end_time
@@ -39,7 +90,10 @@ fact_signature = '(iiissisasii)'
 
 
 def from_dbus_fact(dbus_fact):
-    """unpack the struct into a proper dict"""
+    """Unpack the struct into a proper dict.
+
+    Legacy: to besuperceded by from_dbus_fact_json at some point.
+    """
     return Fact(activity=dbus_fact[4],
                 start_time=dt.datetime.utcfromtimestamp(dbus_fact[1]),
                 end_time=dt.datetime.utcfromtimestamp(dbus_fact[2]) if dbus_fact[2] else None,
@@ -55,6 +109,7 @@ def to_dbus_fact(fact):
     """Perform Fact conversion to D-Bus.
 
     Return the corresponding dbus structure, with supported data types.
+    Legacy: to besuperceded by to_dbus_fact_json at some point.
     """
     return (fact.id or 0,
             timegm(fact.start_time.timetuple()),

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -673,14 +673,11 @@ class Storage(storage.Storage):
 
 
     def __get_todays_facts(self):
-        return self.__get_facts(dt.hday.today())
+        return self.__get_facts(dt.Range.today())
 
-    def __get_facts(self, date, end_date = None, search_terms = ""):
-        split_time = conf.day_start
-        datetime_from = dt.datetime.combine(date, split_time)
-
-        end_date = end_date or date
-        datetime_to = dt.datetime.combine(end_date, split_time) + dt.timedelta(days=1, seconds=-1)
+    def __get_facts(self, range, search_terms=""):
+        datetime_from = range.start
+        datetime_to = range.end
 
         logger.info("searching for facts from {} to {}".format(datetime_from, datetime_to))
 

--- a/src/hamster/storage/storage.py
+++ b/src/hamster/storage/storage.py
@@ -150,8 +150,9 @@ class Storage(object):
         self.end_transaction()
 
 
-    def get_facts(self, start_date, end_date, search_terms):
-        return self.__get_facts(start_date, end_date, search_terms)
+    def get_facts(self, start, end=None, search_terms=""):
+        range = dt.Range.from_start_end(start, end)
+        return self.__get_facts(range, search_terms)
 
 
     def get_todays_facts(self):

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -6,6 +6,7 @@ import datetime as pdt
 import unittest
 import re
 from hamster.lib import datetime as dt
+from hamster.lib.dbus import to_dbus_fact, from_dbus_fact
 from hamster.lib.fact import Fact
 
 
@@ -386,6 +387,19 @@ class TestDatetime(unittest.TestCase):
         _sub = delta - delta
         self.assertEqual(_sub, dt.timedelta())
         self.assertEqual(type(_sub), dt.timedelta)
+
+        
+class TestDBus(unittest.TestCase):
+    def test_round_trip(self):
+        fact = Fact.parse("11:00 12:00 activity, with comma@category,, description, with comma #and #tags")
+        dbus_fact = to_dbus_fact(fact)
+        return_fact = from_dbus_fact(dbus_fact)
+        self.assertEqual(return_fact, fact)
+
+        fact = Fact.parse("11:00 activity")
+        dbus_fact = to_dbus_fact(fact)
+        return_fact = from_dbus_fact(dbus_fact)
+        self.assertEqual(return_fact, fact)
 
 
 if __name__ == '__main__':

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -6,7 +6,14 @@ import datetime as pdt
 import unittest
 import re
 from hamster.lib import datetime as dt
-from hamster.lib.dbus import to_dbus_fact, from_dbus_fact
+from hamster.lib.dbus import (
+    to_dbus_fact,
+    to_dbus_fact_json,
+    to_dbus_range,
+    from_dbus_fact,
+    from_dbus_fact_json,
+    from_dbus_range,
+    )
 from hamster.lib.fact import Fact
 
 
@@ -388,18 +395,31 @@ class TestDatetime(unittest.TestCase):
         self.assertEqual(_sub, dt.timedelta())
         self.assertEqual(type(_sub), dt.timedelta)
 
-        
+
 class TestDBus(unittest.TestCase):
     def test_round_trip(self):
         fact = Fact.parse("11:00 12:00 activity, with comma@category,, description, with comma #and #tags")
+        dbus_fact = to_dbus_fact_json(fact)
+        return_fact = from_dbus_fact_json(dbus_fact)
+        self.assertEqual(return_fact, fact)
+
         dbus_fact = to_dbus_fact(fact)
         return_fact = from_dbus_fact(dbus_fact)
         self.assertEqual(return_fact, fact)
 
         fact = Fact.parse("11:00 activity")
+        dbus_fact = to_dbus_fact_json(fact)
+        return_fact = from_dbus_fact_json(dbus_fact)
+        self.assertEqual(return_fact, fact)
+
         dbus_fact = to_dbus_fact(fact)
         return_fact = from_dbus_fact(dbus_fact)
         self.assertEqual(return_fact, fact)
+
+        range, __ = dt.Range.parse("2020-01-19 11:00 - 2020-01-19 12:00")
+        dbus_range = to_dbus_range(range)
+        return_range = from_dbus_range(dbus_range)
+        self.assertEqual(return_range, range)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The custom fact signature used in the past was hard to extend.
For instance timezone info addition would require a signature change.

Hence pass verbatim fact as a string in [json](https://docs.python.org/3.7/library/json.html) format.
Better change that now while no-one else uses the verbatim interface introduced in #466, 
about 3 months ago.

The replacement D-Bus method `GetFactsJSON` first argument is a range string,
same syntax/parser as the command line. 
This parser understands a single hamster day, a day range, or a precise datetimes range.

This PR is fully backward compatible for the [hamster-shell-extension](https://github.com/projecthamster/hamster-shell-extension),
since that uses `GetTodaysFacts` and `AddFact`, not `AddFactVerbatim`.
Added `GetFactJSON` and `GetTodaysFactsJSON` as well.

`client.get_facts` also should be backward compatible.

With c5178eb1243cdd219d894c33528e1cda90247975 the range granularity for `get_facts` is improved.
Now datetimes are understood (granularity: minute), 
in addition to hamster days (granularity: day, as previously).
