### PR TITLE
Fix hday.today() type

### DIFF
--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -46,6 +46,21 @@ class date(pdt.date):
     def __new__(cls, year, month, day):
         return pdt.date.__new__(cls, year, month, day)
 
+    def __add__(self, other):
+        # python date.__add__ was not type stable prior to 3.8
+        return self.from_pdt(self.to_pdt() + other)
+
+    __radd__ = __add__
+
+    def __sub__(self, other):
+        # python date.__sub__ was not type stable prior to 3.8
+        if isinstance(other, timedelta):
+            return self.from_pdt(self.to_pdt() - other)
+        elif isinstance(other, date):
+            return timedelta.from_pdt(self.to_pdt() - other)
+        else:
+            raise NotImplementedError("subtract {}".format(type(other)))
+
     @classmethod
     def parse(cls, s):
         """Return date from string."""
@@ -72,6 +87,10 @@ class date(pdt.date):
     def from_pdt(cls, d):
         """Convert python date to hamster date."""
         return cls(d.year, d.month, d.day)
+
+    def to_pdt(self):
+        """Convert to python date."""
+        return pdt.date(self.year, self.month, self.day)
 
 # For datetime that will need to be outside the class.
 # Same here for consistency

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -281,6 +281,8 @@ class TestDatetime(unittest.TestCase):
         date_time = dt.datetime(2018, 8, 14, 0, 10)  # 2018-08-14 0:10
         expected = dt.date(2018, 8, 13)
         self.assertEqual(date_time.hday(), expected)
+        today = dt.hday.today()
+        self.assertEqual(type(today), dt.hday)
 
     def test_parse_date(self):
         date = dt.date.parse("2020-01-05")


### PR DESCRIPTION
Should return a `hday`, obviously.
It was sometimes returning a date, due to the timedelta subtraction.