### PR TITLE
return id = 0 upon failure

### DIFF
--- a/src/hamster-service.py
+++ b/src/hamster-service.py
@@ -149,7 +149,7 @@ class Storage(db.Storage, dbus.service.Object):
                             If different from 0, overrides the parsed value.
                             -1 means None.
         Returns:
-            fact id (int), or 0 in case of failure.
+            fact id (int), 0 means failure.
 
         Note: see datetime.utcfromtimestamp documentation
               for the precise meaning of timestamps.
@@ -168,7 +168,7 @@ class Storage(db.Storage, dbus.service.Object):
         elif end_time != 0:
             fact.end_time = dt.datetime.utcfromtimestamp(end_time)
 
-        return self.add_fact(fact) or 0
+        return self.add_fact(fact)
 
 
     @dbus.service.method("org.gnome.Hamster", in_signature='s', out_signature='i')
@@ -184,10 +184,10 @@ class Storage(db.Storage, dbus.service.Object):
             dbus_fact (str): fact in JSON format (cf. from_dbus_fact_json).
 
         Returns:
-            fact id (int), or 0 in case of failure.
+            fact id (int), 0 means failure.
         """
         fact = from_dbus_fact_json(dbus_fact)
-        return self.add_fact(fact) or 0
+        return self.add_fact(fact)
 
 
     @dbus.service.method("org.gnome.Hamster",
@@ -249,7 +249,7 @@ class Storage(db.Storage, dbus.service.Object):
         end_time = end_time or None
         if end_time:
             end_time = dt.datetime.utcfromtimestamp(end_time)
-        return self.update_fact(fact_id, fact, start_time, end_time, temporary) or 0
+        return self.update_fact(fact_id, fact, start_time, end_time, temporary)
 
 
     @dbus.service.method("org.gnome.Hamster",
@@ -265,7 +265,7 @@ class Storage(db.Storage, dbus.service.Object):
             int: new id (0 means failure)
         """
         fact = from_dbus_fact_json(dbus_fact)
-        return self.update_fact(fact_id, fact) or 0
+        return self.update_fact(fact_id, fact)
 
 
     @dbus.service.method("org.gnome.Hamster", in_signature='i')

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -40,6 +40,10 @@ from hamster.lib.fact import Fact
 from hamster.storage import storage
 
 
+# note: "zero id means failure" is quite standard,
+#       and that kind of convention will be mandatory for the dbus interface
+#       (None cannot pass through an integer signature).
+
 class Storage(storage.Storage):
     con = None # Connection will be created on demand
     def __init__(self, unsorted_localized="Unsorted", database_dir=None):
@@ -56,7 +60,8 @@ class Storage(storage.Storage):
                 Directory holding the database file,
                 or None to use the default location.
 
-        Note: Unsorted category id is hard-coded as -1
+        Note: Zero id means failure.
+              Unsorted category id is hard-coded as -1
         """
         storage.Storage.__init__(self)
 
@@ -357,7 +362,10 @@ class Storage(storage.Storage):
         return None
 
     def __get_category_id(self, name):
-        """returns category by it's name"""
+        """Return category id from its name.
+
+        0 means none found.
+        """
         if not name:
             # Unsorted
             return -1
@@ -374,7 +382,7 @@ class Storage(storage.Storage):
         if res:
             return res['id']
 
-        return None
+        return 0
 
     def _dbfact_to_libfact(self, db_fact):
         """Convert a db fact (coming from __group_facts) to Fact."""
@@ -669,7 +677,7 @@ class Storage(storage.Storage):
         return fact_id
 
     def __last_insert_rowid(self):
-        return self.fetchone("SELECT last_insert_rowid();")[0]
+        return self.fetchone("SELECT last_insert_rowid();")[0] or 0
 
 
     def __get_todays_facts(self):


### PR DESCRIPTION
Cleanup: returned `id` is always an `int`, never `None`.