### PR TITLE
Richer relative times

### DIFF
--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -291,8 +291,9 @@ class CustomFactController(gobject.GObject):
         with self.cmdline.handler_block(self.cmdline.checker):
             self.cmdline.set_text(label)
             if select:
-                time_str = self.cmdline_fact.range.format(default_day=self.date)
-                self.cmdline.select_region(0, len(time_str))
+                # select the range string exactly (without separator)
+                __, rest = dt.Range.parse(label, position="head", separator="")
+                self.cmdline.select_region(0, len(label) - len(rest))
 
     def update_fields(self):
         """Update gui fields content."""

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -495,14 +495,14 @@ class Range():
         if position == "exact":
             p = "^{}$".format(cls.pattern())
         elif position == "head":
-            # require at least a space after, to avoid matching 10.00@cat
+            # ( )?: require either only the range (no rest),
+            #       or separator between range and rest,
+            #       to avoid matching 10.00@cat
             # .*? so rest is as little as possible
-            p = "^{}{}(?P<rest>.*?)$".format(cls.pattern(), separator)
+            p = "^{}( {}(?P<rest>.*?) )?$".format(cls.pattern(), separator)
         elif position == "tail":
-            # require at least a space after, to avoid matching #10.00
-            # .*? so rest is as little as possible
-            p = "^(?P<rest>.*?){}{}$".format(separator, cls.pattern())
-        # no need to compile, recent patterns are cached by re
+            p = "^( (?P<rest>.*?){} )? {}$".format(separator, cls.pattern())
+        # No need to compile, recent patterns are cached by re.
         # DOTALL, so rest may contain newlines
         # (important for multiline descriptions)
         m = re.search(p, text, flags=re.VERBOSE | re.DOTALL)
@@ -512,7 +512,7 @@ class Range():
         elif position == "exact":
             rest = ""
         else:
-            rest = m.group("rest")
+            rest = m.group("rest") or ""
 
         if m.group('firstday'):
             # only day given for start

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -370,7 +370,8 @@ class datetime(pdt.datetime):
                 (?P<relative>
                     --                        # double dash: None
                    |                          # or
-                    -\d{{1,3}}                # minus 1, 2 or 3 digits: relative time
+                    [-+]                      # minus or plus: relative to ref
+                    \d{{1,3}}                 # 1, 2 or 3 digits
                 )
             |                             # or
                 (?P<date>{})?                 # maybe date
@@ -525,8 +526,8 @@ class Range():
                                                default_day=default_day)
             if isinstance(start, pdt.timedelta):
                 # relative to ref, actually
-                delta1 = start
-                start = ref + delta1
+                assert ref, "relative start needs ref"
+                start = ref + start
 
         if m.group('lastday'):
             lastday = hday.parse(m.group('lastday'))
@@ -539,16 +540,9 @@ class Range():
                                              m="minute2", r="relative2",
                                              default_day=end_default_day)
             if isinstance(end, pdt.timedelta):
-                # relative to start, actually
-                delta2 = end
-                if delta2 > pdt.timedelta(0):
-                    # wip: currently not reachable
-                    # (would need [-\+]\d{1,3} in the parser).
-                    end = start + delta2
-                elif ref and delta2 < pdt.timedelta(0):
-                    end = ref + delta2
-                else:
-                    end = None
+                # relative to ref, actually
+                assert ref, "relative end needs ref"
+                end = ref + end
 
         return Range(start, end), rest
 

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -574,7 +574,8 @@ class Range():
               |
               (?P<duration>
                   (?<![+-])       # negative lookbehind: no sign
-                  \d{{1,3}})      # 1, 2 or 3 digits
+                  \d{{1,3}}       # 1, 2 or 3 digits
+              )
             )
             )?                    # end time is facultative
             """.format(datetime.pattern(1), date.pattern(detailed=False),

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -534,6 +534,9 @@ class Range():
             end = lastday.end
         elif firstday:
             end = firstday.end
+        elif m.group('duration'):
+            duration = int(m.group('duration'))
+            end = start + timedelta(minutes=duration)
         else:
             end_default_day = start.hday() if start else default_day
             end = datetime._extract_datetime(m, d="date2", h="hour2",
@@ -568,6 +571,10 @@ class Range():
               {}                  # datetime: relative2 or (date2, hour2, and minute2)
               |                   # or
               (?P<lastday>{})     # date without time
+              |
+              (?P<duration>
+                  (?<![+-])       # negative lookbehind: no sign
+                  \d{{1,3}})      # 1, 2 or 3 digits
             )
             )?                    # end time is facultative
             """.format(datetime.pattern(1), date.pattern(detailed=False),

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -205,7 +205,16 @@ class Fact(object):
     def serialized(self, range_pos="head", default_day=None):
         """Return a string fully representing the fact."""
         name = self.serialized_name()
-        datetime = self.range.format(default_day=default_day)
+        if range_pos == "head":
+            # Is activity starting with a range ?
+            subfact = Fact.parse(self.activity, range_pos=range_pos,
+                                 default_day=default_day)
+            need_explicit = bool(subfact.range)
+        else:
+            # TODO: should check last tag.
+            need_explicit = False
+        datetime = self.range.format(default_day=default_day,
+                                     explicit_none=need_explicit)
         # no need for space if name or datetime is missing
         space = " " if name and datetime else ""
         assert range_pos in ("head", "tail")

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -206,7 +206,7 @@ class Fact(object):
         """Return a string fully representing the fact."""
         name = self.serialized_name()
         if range_pos == "head":
-            # Is activity starting with a range ?
+            # Is activity starting range-like ?
             subfact = Fact.parse(self.activity, range_pos=range_pos,
                                  default_day=default_day)
             need_explicit = bool(subfact.range)

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -92,23 +92,7 @@ def parse_fact(text, range_pos="head", default_day=None, ref="now"):
     split = remaining_text.rsplit('@', maxsplit=1)
     activity = split[0]
     category = split[1] if len(split) > 1 else ""
-    if looks_like_time(activity):
-        # want meaningful activities
-        return res
     res["activity"] = activity
     res["category"] = category
 
     return res
-
-
-_time_fragment_re = [
-    re.compile("^-$"),
-    re.compile("^([0-1]?[0-9]?|[2]?[0-3]?)$"),
-    re.compile("^([0-1]?[0-9]|[2][0-3]):?([0-5]?[0-9]?)$"),
-    re.compile("^([0-1]?[0-9]|[2][0-3]):([0-5][0-9])-?([0-1]?[0-9]?|[2]?[0-3]?)$"),
-    re.compile("^([0-1]?[0-9]|[2][0-3]):([0-5][0-9])-([0-1]?[0-9]|[2][0-3]):?([0-5]?[0-9]?)$"),
-]
-def looks_like_time(fragment):
-    if not fragment:
-        return False
-    return any((r.match(fragment) for r in _time_fragment_re))

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -38,7 +38,6 @@ from hamster.lib import stuff
 from hamster.lib import graphics
 from hamster.lib.configuration import runtime
 from hamster.lib.fact import Fact
-from hamster.lib.parsing import looks_like_time
 
 
 def extract_search(text):

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -358,10 +358,18 @@ class TestDatetime(unittest.TestCase):
         (start, end), rest = dt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:30")
         self.assertEqual(end, None)
+        s = "+25 activity"
+        (start, end), rest = dt.Range.parse(s, position="head", ref=ref)
+        self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 14:20")
+        self.assertEqual(end, None)
         s = "-55 -25 activity"
         (start, end), rest = dt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:00")
         self.assertEqual(end.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:30")
+        s = "+25 +55 activity"
+        (start, end), rest = dt.Range.parse(s, position="head", ref=ref)
+        self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 14:20")
+        self.assertEqual(end.strftime("%Y-%m-%d %H:%M"), "2019-11-29 14:50")
         s = "-55 -120 activity"
         (start, end), rest = dt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:00")

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -374,6 +374,10 @@ class TestDatetime(unittest.TestCase):
         (start, end), rest = dt.Range.parse(s, position="head", ref=ref)
         self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:00")
         self.assertEqual(end.strftime("%Y-%m-%d %H:%M"), "2019-11-29 11:55")
+        s = "-50 20 activity"
+        (start, end), rest = dt.Range.parse(s, position="head", ref=ref)
+        self.assertEqual(start.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:05")
+        self.assertEqual(end.strftime("%Y-%m-%d %H:%M"), "2019-11-29 13:25")
 
         s = "2019-12-05"  # single hamster day
         (start, end), rest = dt.Range.parse(s, ref=ref)

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -46,6 +46,12 @@ class TestFactParsing(unittest.TestCase):
         assert not activity.category
         assert not activity.description
 
+    def test_only_range(self):
+        fact = Fact.parse("-20")
+        assert not fact.activity
+        fact = Fact.parse("-20 -10")
+        assert not fact.activity
+
     def test_with_start_time(self):
         # with time
         activity = Fact.parse("12:35 with start time")


### PR DESCRIPTION
This started as a fix to the following behavior:
to enter `-10 activity`, while typing, 
`-10` was interpreted as an activity, until the `a` was typed, 
and only then `-10` was interpreted as a start.
Now `-10` is interpreted as a start right after `1` is typed.
*Note: There is no way to know what the user has in mind until the second character is typed, 
so at first `-` appears in the activity, which is fine actually (tried to swallow it, worse down the line)*

Then, since parser was touched, it became irresistible to add the possibility for positive
relative times, entered as `+nnn` (plus sign followed by 1 to 3 digits).
Signed relative times (e.g.  `-10`or `+10`) are always relative to reference (normally, `now`).

Finally my preferred one; end time can be replaced with the fact duration (1 to 3 digits without any sign):
`-50 20` means start 50 min ago, duration 20 minutes (hence end 30 minutes ago).

Note: double dash  `--` can be used instead of a relative time, mean an explicit `None`,
so any kind of activity can be entered now (even beginning time-like),
provided both `start` and `end` are explicit.
