### PR TITLE
Fix wayland popup positions

### DIFF
--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -68,14 +68,12 @@ class CustomFactController(gobject.GObject):
         self.end_date = widgets.Calendar(widget=self.get_widget("end date"),
                                          expander=self.get_widget("end date expander"))
 
-        self.end_time = widgets.TimeInput()
-        self.get_widget("end time box").add(self.end_time)
+        self.end_time = widgets.TimeInput(parent=self.get_widget("end time box"))
 
         self.start_date = widgets.Calendar(widget=self.get_widget("start date"),
                                            expander=self.get_widget("start date expander"))
 
-        self.start_time = widgets.TimeInput()
-        self.get_widget("start time box").add(self.start_time)
+        self.start_time = widgets.TimeInput(parent=self.get_widget("start time box"))
 
         self.tags_entry = widgets.TagsEntry()
         self.get_widget("tags box").add(self.tags_entry)

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -55,8 +55,7 @@ class CustomFactController(gobject.GObject):
         self.activity_entry = widgets.ActivityEntry(widget=self.get_widget('activity'),
                                                     category_widget=self.category_entry)
 
-        self.cmdline = widgets.CmdLineEntry()
-        self.get_widget("command line box").add(self.cmdline)
+        self.cmdline = widgets.CmdLineEntry(parent=self.get_widget("command line box"))
         self.cmdline.connect("focus_in_event", self.on_cmdline_focus_in_event)
         self.cmdline.connect("focus_out_event", self.on_cmdline_focus_out_event)
 

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -209,7 +209,8 @@ class CmdLineEntry(gtk.Entry):
         self.original_fact = None
 
         self.popup = gtk.Window(type = gtk.WindowType.POPUP)
-        self.popup.set_transient_for(self.get_ancestor(gtk.Window))
+        self.popup.set_transient_for(self.get_ancestor(gtk.Window))  # position
+        self.popup.set_attached_to(self)  # attributes
 
         box = gtk.Frame()
         box.set_shadow_type(gtk.ShadowType.IN)

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -209,6 +209,7 @@ class CmdLineEntry(gtk.Entry):
         self.original_fact = None
 
         self.popup = gtk.Window(type = gtk.WindowType.POPUP)
+        self.popup.set_type_hint(gdk.WindowTypeHint.COMBO)
         self.popup.set_transient_for(self.get_ancestor(gtk.Window))  # position
         self.popup.set_attached_to(self)  # attributes
 

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -200,7 +200,7 @@ class CompleteTree(graphics.Scene):
 
 class CmdLineEntry(gtk.Entry):
     def __init__(self, updating=True, **kwargs):
-        gtk.Entry.__init__(self)
+        gtk.Entry.__init__(self, **kwargs)
 
         # default day for times without date
         self.default_day = None
@@ -209,6 +209,8 @@ class CmdLineEntry(gtk.Entry):
         self.original_fact = None
 
         self.popup = gtk.Window(type = gtk.WindowType.POPUP)
+        self.popup.set_transient_for(self.get_ancestor(gtk.Window))
+
         box = gtk.Frame()
         box.set_shadow_type(gtk.ShadowType.IN)
         self.popup.add(box)

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -209,9 +209,9 @@ class CmdLineEntry(gtk.Entry):
         self.original_fact = None
 
         self.popup = gtk.Window(type = gtk.WindowType.POPUP)
-        self.popup.set_type_hint(gdk.WindowTypeHint.COMBO)
-        self.popup.set_transient_for(self.get_ancestor(gtk.Window))  # position
+        self.popup.set_type_hint(gdk.WindowTypeHint.COMBO)  # why not
         self.popup.set_attached_to(self)  # attributes
+        self.popup.set_transient_for(self.get_ancestor(gtk.Window))  # position
 
         box = gtk.Frame()
         box.set_shadow_type(gtk.ShadowType.IN)

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -33,8 +33,8 @@ class TimeInput(gtk.Entry):
     }
 
 
-    def __init__(self, time = None, start_time = None):
-        gtk.Entry.__init__(self)
+    def __init__(self, time=None, start_time=None, **kwargs):
+        gtk.Entry.__init__(self, **kwargs)
         self.news = False
         self.set_width_chars(7) #7 is like 11:24pm
 
@@ -43,6 +43,10 @@ class TimeInput(gtk.Entry):
 
 
         self.popup = gtk.Window(type = gtk.WindowType.POPUP)
+        self.popup.set_type_hint(gdk.WindowTypeHint.COMBO)  # why not
+        self.popup.set_attached_to(self)  # attributes
+        self.popup.set_transient_for(self.get_ancestor(gtk.Window))  # position
+
         time_box = gtk.ScrolledWindow()
         time_box.set_policy(gtk.PolicyType.NEVER, gtk.PolicyType.ALWAYS)
         time_box.set_shadow_type(gtk.ShadowType.IN)


### PR DESCRIPTION
Fix #339.
The `gdk.WindowTypeHint.COMBO` and `set_attached_to` lines 
do not do much, but seem right.