### PR TITLE
build: Install the Bash completion file in the right place

### DIFF
--- a/wscript
+++ b/wscript
@@ -48,7 +48,7 @@ def build(bld):
     bld.install_as('${BINDIR}/hamster', "src/hamster-cli.py", chmod=Utils.O755)
 
 
-    bld.install_files('${PREFIX}/share/bash-completion/completion',
+    bld.install_files('${PREFIX}/share/bash-completion/completions',
                       'src/hamster.bash')
 
 


### PR DESCRIPTION
Bash loads completion scripts from 2 directories:

*   $(syscondir)/bash_completion.d/
*   $(datadir)/bash-completion/completions/

The former is meant to be used by local administrators to drop their own
files in, and the latter is what software installers should use.

In the past Hamster used to install its completion file in the former,
but this was changed with 1d562615a5e5e2c97be3aa379c4dea3709f26f04.

Unfortunately that commit had a typo and the last "s" was missing from
the path.

This commit fixes that typo.