### PR TITLE
Install the service executables in libexecdir

### DIFF
--- a/org.gnome.hamster.Windows.service.in
+++ b/org.gnome.hamster.Windows.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.gnome.Hamster.WindowServer
-Exec=@LIBDIR@/hamster/hamster-windows-service
+Exec=@LIBEXECDIR@/hamster/hamster-windows-service

--- a/org.gnome.hamster.service.in
+++ b/org.gnome.hamster.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.gnome.Hamster
-Exec=@LIBDIR@/hamster/hamster-service
+Exec=@LIBEXECDIR@/hamster/hamster-service

--- a/wscript
+++ b/wscript
@@ -33,6 +33,8 @@ def configure(conf):
 
 
 def options(opt):
+    opt.load('gnu_dirs')
+
     # the waf default value is /usr/local, which causes issues (e.g. #309)
     # opt.parser.set_defaults(prefix='/usr') did not update the help string,
     # hence need to replace the whole option

--- a/wscript
+++ b/wscript
@@ -43,8 +43,8 @@ def options(opt):
 
 
 def build(bld):
-    bld.install_as('${LIBDIR}/hamster/hamster-service', "src/hamster-service.py", chmod=Utils.O755)
-    bld.install_as('${LIBDIR}/hamster/hamster-windows-service', "src/hamster-windows-service.py", chmod=Utils.O755)
+    bld.install_as('${LIBEXECDIR}/hamster/hamster-service', "src/hamster-service.py", chmod=Utils.O755)
+    bld.install_as('${LIBEXECDIR}/hamster/hamster-windows-service', "src/hamster-windows-service.py", chmod=Utils.O755)
     bld.install_as('${BINDIR}/hamster', "src/hamster-cli.py", chmod=Utils.O755)
 
 


### PR DESCRIPTION
This is the proper directory according to the GNU guidelines:

> The directory for installing executable programs to be run by other
> programs rather than by users.

https://www.gnu.org/prep/standards/html_node/Directory-Variables.html#index-libexecdir

Libexecdir used to be absent from the FHS but it was added in version
3.0 of the standard, which was released in 2015:

> /usr/libexec includes internal binaries that are not intended to be
> executed directly by users or shell scripts. Applications may use a
> single subdirectory under /usr/libexec.

https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#usrlibexec

Those executables are the launchers for the background services, and are
not intended to be run by users (e.g the Linux one is run by DBus) which
makes libexecdir the better place to install them.

---

The default as recommanded by GNU is `$(prefix)/libexec`. This is what Linux distributions like Fedora use.

However, other distributions (most notably Debian) mandate in their policy that `libexecdir` must be `libdir`. The second commit in this branch makes it possible for those distributions to override the default.