### PR TITLE
Fix crash when editing or deleting an activity from overview

### DIFF
--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -22,8 +22,10 @@
 import dbus
 import logging
 logger = logging.getLogger(__name__)   # noqa: E402
+import sys
 
 from calendar import timegm
+from distutils.version import LooseVersion
 from gi.repository import GObject as gobject
 from textwrap import dedent
 
@@ -38,6 +40,16 @@ from hamster.lib.dbus import (
     )
 from hamster.lib.fact import Fact, FactError
 from hamster.lib import datetime as dt
+
+
+# bug fixed in dbus-python 1.2.14 (released on 2019-11-25)
+assert not (
+    sys.version_info >= (3, 8)
+    and LooseVersion(dbus.__version__) < LooseVersion("1.2.14")
+    ), """python3.8 changed str(<dbus integers>).
+       That broke hamster (https://github.com/projecthamster/hamster/issues/477).
+       Please upgrade to dbus-python >= 1.2.14.
+    """
 
 
 class Storage(gobject.GObject):

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -841,7 +841,7 @@ class Storage(storage.Storage):
             return
         ids = ",".join((str(id) for id in ids))
         logger.info("removing fact #{} from index".format(ids))
-        self.execute(["DELETE FROM fact_index where id = ?"], ids)
+        self.execute("DELETE FROM fact_index where id in (%s)" % ids)
 
 
     def __check_index(self, start_date, end_date):

--- a/src/hamster/storage/db.py
+++ b/src/hamster/storage/db.py
@@ -841,7 +841,7 @@ class Storage(storage.Storage):
             return
         ids = ",".join((str(id) for id in ids))
         logger.info("removing fact #{} from index".format(ids))
-        self.execute("DELETE FROM fact_index where id in (%s)" % ids)
+        self.execute(["DELETE FROM fact_index where id = ?"], ids)
 
 
     def __check_index(self, start_date, end_date):


### PR DESCRIPTION
```
dbus.exceptions.DBusException: org.freedesktop.DBus.Python.sqlite3.OperationalError:
Traceback (most recent call last):
  File "/home/sh_zam/workspace/hamster/src/hamster/storage/db.py", line 844, in __remove_index
    self.execute("DELETE FROM fact_index where id in (%s)" % ids)
  File "/home/sh_zam/workspace/hamster/src/hamster/storage/db.py", line 939, in execute
    cur.execute(state, param)
sqlite3.OperationalError: near "(": syntax error``