### PR TITLE
Add timedelta.total_minutes()

### DIFF
--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -670,6 +670,7 @@ class timedelta(pdt.timedelta):
         """Return a string representation, according to the format string fmt."""
         allowed = ("human", "HH:MM")
 
+        # TODO: should use total_minutes
         total_s = self.total_seconds()
         if total_s < 0:
             # return a warning
@@ -693,3 +694,8 @@ class timedelta(pdt.timedelta):
         else:
             raise NotImplementedError(
                 "'{}' not in allowed formats: {}".format(fmt, allowed))
+
+    def total_minutes(self):
+        """Return the duration in minutes (float)."""
+        return self.total_seconds() / 60
+

--- a/src/hamster/lib/datetime.py
+++ b/src/hamster/lib/datetime.py
@@ -621,21 +621,22 @@ class timedelta(pdt.timedelta):
 
     Should replace the python datetime.timedelta in any customer code.
     Specificities:
-    - rounded to minutes
     - conversion to and from string facilities
+    Note: granularity is the same as the original python timedelta
+          (only datetimes should be truncated).
     """
 
     def __new__(cls, days=0, seconds=0, microseconds=0,
                 milliseconds=0, minutes=0, hours=0, weeks=0):
-            # round down to zero seconds and microseconds
-            return pdt.timedelta.__new__(cls,
-                                         days=days,
-                                         seconds=seconds,
-                                         microseconds=microseconds,
-                                         milliseconds=milliseconds,
-                                         minutes=minutes,
-                                         hours=hours,
-                                         weeks=weeks)
+        # Tempted to round down ? Resist. Not so useful + issues down the line.
+        return pdt.timedelta.__new__(cls,
+                                     days=days,
+                                     seconds=seconds,
+                                     microseconds=microseconds,
+                                     milliseconds=milliseconds,
+                                     minutes=minutes,
+                                     hours=hours,
+                                     weeks=weeks)
 
     # timedelta subclassing is not type stable yet
     def __add__(self, other):

--- a/src/hamster/lib/stuff.py
+++ b/src/hamster/lib/stuff.py
@@ -155,7 +155,9 @@ def month(view_date):
 
 
 def duration_minutes(duration):
-    """returns minutes from duration, otherwise we keep bashing in same math"""
+    """Returns minutes from duration, otherwise we keep bashing in same math.
+    Deprecated, use dt.timedelta.total_minutes instead.
+    """
     if isinstance(duration, dt.timedelta):
         return duration.total_seconds() / 60
     elif isinstance(duration, (int, float)):

--- a/tests/stuff_test.py
+++ b/tests/stuff_test.py
@@ -425,6 +425,10 @@ class TestDatetime(unittest.TestCase):
         self.assertEqual(_sub, dt.timedelta())
         self.assertEqual(type(_sub), dt.timedelta)
 
+    def test_timedelta(self):
+        delta = dt.timedelta(seconds=90)
+        self.assertEqual(delta.total_minutes(), 1.5)
+
 
 class TestDBus(unittest.TestCase):
     def test_round_trip(self):


### PR DESCRIPTION
`timedelta.total_minutes()` will replace `format_duration` in v4.0.