### PR TITLE
cmdline gui small improvements

### DIFF
--- a/data/edit_activity.ui
+++ b/data/edit_activity.ui
@@ -94,9 +94,28 @@
           </packing>
         </child>
         <child>
-          <object class="GtkAlignment" id="command line box">
+          <object class="GtkBox" id="cmdline box">
+            <property name="name">cmdline box</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">cmdline</property>
+                <attributes>
+                  <attribute name="style" value="italic"/>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
             <child>
               <placeholder/>
             </child>

--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -55,7 +55,7 @@ class CustomFactController(gobject.GObject):
         self.activity_entry = widgets.ActivityEntry(widget=self.get_widget('activity'),
                                                     category_widget=self.category_entry)
 
-        self.cmdline = widgets.CmdLineEntry(parent=self.get_widget("command line box"))
+        self.cmdline = widgets.CmdLineEntry(parent=self.get_widget("cmdline box"))
         self.cmdline.connect("focus_in_event", self.on_cmdline_focus_in_event)
         self.cmdline.connect("focus_out_event", self.on_cmdline_focus_out_event)
 

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -261,6 +261,7 @@ class CmdLineEntry(gtk.Entry):
         if self.popup.get_visible():
             self.popup.hide()
         else:
+            self.grab_focus()
             self.show_suggestions(self.get_text())
 
     def on_key_press(self, entry, event=None):

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -267,7 +267,7 @@ class CmdLineEntry(gtk.Entry):
         if event.keyval in (gdk.KEY_BackSpace, gdk.KEY_Delete):
             self.ignore_stroke = True
 
-        elif event.keyval in (gdk.KEY_Return, gdk.KEY_Escape):
+        elif event.keyval in (gdk.KEY_Return, gdk.KEY_KP_Enter, gdk.KEY_Escape):
             self.popup.hide()
             self.set_position(-1)
 


### PR DESCRIPTION
- Numpad Enter was doing nothing in the gui cmdline entry.

- 926ca6bb9fa369a5c90e67fd85b3be4d3aabace4: cleaner, and moreover,
updates the entry content prior to showing the suggestions. Fixes the following bug:
> new activity
click on start time, select a time
click on the cmdline dropdown icon,
select a completion; the text is changed but not the fields

- 5331e84a004d2a40c4b45ef666db0f15f5153d82
add "cmdline" label
(bug reports were confusing, cf. #515)
By the way, change to a GtkBox (why an alignment ?)