### PR TITLE
Add libglib2.0-dev-bin Ubuntu dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ https://snapcraft.io/hamster-snap
 ###### Ubuntu (tested in 19.04 and 18.04)
 
 ```bash
-sudo apt install gettext intltool python3-gi-cairo python3-distutils python3-dbus python3-xdg libglib2.0-dev-bin
+sudo apt install gettext intltool python3-gi-cairo python3-distutils python3-dbus python3-xdg libglib2.0-dev
 # and for documentation
 sudo apt install gnome-doc-utils yelp
 ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ https://snapcraft.io/hamster-snap
 ###### Ubuntu (tested in 19.04 and 18.04)
 
 ```bash
-sudo apt install gettext intltool python3-gi-cairo python3-distutils python3-dbus python3-xdg
+sudo apt install gettext intltool python3-gi-cairo python3-distutils python3-dbus python3-xdg libglib2.0-dev-bin
 # and for documentation
 sudo apt install gnome-doc-utils yelp
 ```


### PR DESCRIPTION
At least Ubuntu 19.10 needs it for glib-genmarshal to be available