### PR TITLE
Fix completion in categories TreeView

### DIFF
--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -637,7 +637,7 @@ class CategoryEntry():
         else:
             # return whether the entered string is
             # anywhere in the first column data
-            return key.strip() in self.model.get_value(iter, 0)
+            return key.strip() in self.model.get_value(iter, 0).lower()
 
     def on_action_activated(self, completion, index):
         if index == self.unsorted_action_index:


### PR DESCRIPTION
Because `key` was being returned in lowercase, matching would fail.