### PR TITLE
hamster: explicitly set application ID and prgname on startup

### DIFF
--- a/src/hamster-cli.py
+++ b/src/hamster-cli.py
@@ -98,13 +98,11 @@ class Hamster(gtk.Application):
     Can be accessed across D-Bus with the 'org.gnome.Hamster.GUI' id.
     """
 
-    __app_id__ = "org.gnome.Hamster.GUI"
-
     def __init__(self):
         # inactivity_timeout: How long (ms) the service should stay alive
         #                     after all windows have been closed.
         gtk.Application.__init__(self,
-                                 application_id=self.__app_id__,
+                                 application_id="org.gnome.Hamster.GUI",
                                  #inactivity_timeout=10000,
                                  register_session=True)
 
@@ -144,8 +142,10 @@ class Hamster(gtk.Application):
 
     def on_startup(self, data=None):
         logger.debug("startup")
-        glib.set_application_name(self.__app_id__)
-        glib.set_prgname(self.__app_id__)
+        # Must be the same as application_id. Won't be required with gtk4.
+        glib.set_prgname(self.get_application_id())
+        # localized name, but let's keep it simple.
+        glib.set_application_name("Hamster")
 
     def _open_window(self, name, data=None):
         logger.debug("opening '{}'".format(name))

--- a/src/hamster-cli.py
+++ b/src/hamster-cli.py
@@ -30,6 +30,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk as gtk
 from gi.repository import Gio as gio
+from gi.repository import GLib as glib
 
 import hamster
 
@@ -97,11 +98,13 @@ class Hamster(gtk.Application):
     Can be accessed across D-Bus with the 'org.gnome.Hamster.GUI' id.
     """
 
+    __app_id__ = "org.gnome.Hamster.GUI"
+
     def __init__(self):
         # inactivity_timeout: How long (ms) the service should stay alive
         #                     after all windows have been closed.
         gtk.Application.__init__(self,
-                                 application_id="org.gnome.Hamster.GUI",
+                                 application_id=self.__app_id__,
                                  #inactivity_timeout=10000,
                                  register_session=True)
 
@@ -141,6 +144,8 @@ class Hamster(gtk.Application):
 
     def on_startup(self, data=None):
         logger.debug("startup")
+        glib.set_application_name(self.__app_id__)
+        glib.set_prgname(self.__app_id__)
 
     def _open_window(self, name, data=None):
         logger.debug("opening '{}'".format(name))


### PR DESCRIPTION
Under wayland, passing application_id to Gtk.Application.Init()
is not sufficient to set the application ID and program name
so that the shell sees it. See e.g.

https://www.programcreek.com/python/example/87806/gi.repository.GLib.set_prgname
https://gitlab.gnome.org/GNOME/gtk/issues/653
https://gitlab.gnome.org/GNOME/gtk/commit/72ec8963d7df0e39f688838e42445c869e4875c9

This should fix #541.