### PR TITLE
build: Add a Flatpak manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ hamster-time-tracker-*.tar.gz
 .lock-waf*
 build
 *.deb
+.flatpak-builder

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build-aux/flatpak/shared-modules"]
+	path = build-aux/flatpak/shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/build-aux/flatpak/org.gnome.Hamster.GUI.json
+++ b/build-aux/flatpak/org.gnome.Hamster.GUI.json
@@ -1,0 +1,64 @@
+{
+  "id": "org.gnome.Hamster.GUI",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "3.34",
+  "sdk": "org.gnome.Sdk",
+  "command": "hamster",
+  "finish-args": [
+    "--socket=x11",
+    "--socket=wayland",
+    "--own-name=org.gnome.Hamster"
+  ],
+  "modules": [
+    "shared-modules/intltool/intltool-0.51.json",
+    {
+      "name": "dbus-python",
+      "buildsystem": "simple",
+      "build-commands": [
+        "pip3 install --no-deps --no-use-pep517 --prefix=${FLATPAK_DEST} ."
+      ],
+      "cleanup": [
+        "*.la"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://files.pythonhosted.org/packages/source/d/dbus-python/dbus-python-1.2.16.tar.gz",
+          "sha256": "11238f1d86c995d8aed2e22f04a1e3779f0d70e587caffeab4857f3c662ed5a4"
+        }
+      ]
+    },
+    {
+      "name": "pyxdg",
+      "buildsystem": "simple",
+      "build-commands": [
+        "pip3 install --no-deps --no-use-pep517 --prefix=${FLATPAK_DEST} ."
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://files.pythonhosted.org/packages/source/p/pyxdg/pyxdg-0.26.tar.gz",
+          "sha256": "fe2928d3f532ed32b39c32a482b54136fe766d19936afc96c8f00645f9da1a06"
+        }
+      ]
+    },
+    {
+      "name": "hamster",
+      "buildsystem": "simple",
+      "build-commands": [
+        "./waf configure -vv --prefix=${FLATPAK_DEST}",
+        "./waf build -vv",
+        "./waf install"
+      ],
+      "post-install": [
+        "rm -f ${FLATPAK_DEST}/share/icons/hicolor/icon-theme.cache"
+      ],
+      "sources": [
+        {
+          "type": "dir",
+          "path": "../.."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This allows building the master branch of Hamster with a simple command:

$ flatpak-builder _build build-aux/flatpak/org.gnome.Hamster.json

---

For those who don't know Flatpak much, here are a few additional instructions.

1. you need to install Flatpak, Flatpak Builder and configure the Flathub remote: https://flatpak.org/setup/
2. you will need to install the GNOME platform and sdk to build;
3. to make rebuilds faster you want to use the `--ccache` and `--force-clean` options;
4. once the app is built, you need to export it to a local repo, configure that local repo, then install from that repo; this can be automated with the `--install` and `--user` options;

All in all, the following two commands should do the right thing:

```
$ flatpak install flathub org.gnome.Platform//3.34 org.gnome.Sdk//3.34
$ flatpak-builder --force-clean --ccache --user --install _build build-aux/flatpak/org.gnome.Hamster.GUI.json
```

If this is merged, we can look at having automatic builds in your CI, published to a development repo, etc…

And then I can help you send the next release to Flathub if you're interested. slightly_smiling_face