### PR TITLE
No start override

### DIFF
--- a/src/hamster-service.py
+++ b/src/hamster-service.py
@@ -135,7 +135,7 @@ class Storage(db.Storage, dbus.service.Object):
 
     # facts
     @dbus.service.method("org.gnome.Hamster", in_signature='siib', out_signature='i')
-    def AddFact(self, fact_str, start_time, end_time, temporary=False):
+    def AddFact(self, fact_str, start_time, end_time, temporary):
         """Add fact specified by a string.
 
         To fully use the hamster fact parser, as on the cmdline,
@@ -151,6 +151,9 @@ class Storage(db.Storage, dbus.service.Object):
             end_time (int): Start datetime timestamp.
                             If different from 0, overrides the parsed value.
                             -1 means None.
+            temporary (boolean): historical, ignored, but needed to
+                                 keep the method signature stable.
+                                 Do not forget to pass something (e.g. False)!
         Returns:
             fact id (int), 0 means failure.
 
@@ -242,7 +245,7 @@ class Storage(db.Storage, dbus.service.Object):
 
 
     @dbus.service.method("org.gnome.Hamster", in_signature='isiib', out_signature='i')
-    def UpdateFact(self, fact_id, fact, start_time, end_time, temporary = False):
+    def UpdateFact(self, fact_id, fact, start_time, end_time, temporary):
         start_time = start_time or None
         if start_time:
             start_time = dt.datetime.utcfromtimestamp(start_time)

--- a/src/hamster-service.py
+++ b/src/hamster-service.py
@@ -138,13 +138,15 @@ class Storage(db.Storage, dbus.service.Object):
     def AddFact(self, fact_str, start_time, end_time, temporary=False):
         """Add fact specified by a string.
 
+        To fully use the hamster fact parser, as on the cmdline,
+        just pass 0 for start_time and end_time.
+
         Args:
             fact_str (str): string to be parsed.
             start_time (int): Start datetime timestamp.
                               For backward compatibility with the
                               gnome shell extension,
-                              0 is special and means dt.datetime.now().
-                              Otherwise, overrides the parsed value.
+                              If different from 0, overrides the parsed value.
                               -1 means None.
             end_time (int): Start datetime timestamp.
                             If different from 0, overrides the parsed value.
@@ -159,9 +161,7 @@ class Storage(db.Storage, dbus.service.Object):
 
         if start_time == -1:
             fact.start_time = None
-        elif start_time == 0:
-            fact.start_time = dt.datetime.now()
-        else:
+        elif start_time != 0:
             fact.start_time = dt.datetime.utcfromtimestamp(start_time)
 
         if end_time == -1:

--- a/src/hamster-service.py
+++ b/src/hamster-service.py
@@ -138,20 +138,17 @@ class Storage(db.Storage, dbus.service.Object):
     def AddFact(self, fact_str, start_time, end_time, temporary):
         """Add fact specified by a string.
 
+        If the parsed fact has no start, then now is used.
         To fully use the hamster fact parser, as on the cmdline,
         just pass 0 for start_time and end_time.
 
         Args:
             fact_str (str): string to be parsed.
-            start_time (int): Start datetime timestamp.
-                              For backward compatibility with the
-                              gnome shell extension,
-                              If different from 0, overrides the parsed value.
+            start_time (int): Start datetime ovveride timestamp (ignored if 0).
                               -1 means None.
-            end_time (int): Start datetime timestamp.
-                            If different from 0, overrides the parsed value.
+            end_time (int): datetime ovveride timestamp (ignored if 0).
                             -1 means None.
-            temporary (boolean): historical, ignored, but needed to
+            #temporary (boolean): historical mystery, ignored, but needed to
                                  keep the method signature stable.
                                  Do not forget to pass something (e.g. False)!
         Returns:
@@ -161,6 +158,10 @@ class Storage(db.Storage, dbus.service.Object):
               for the precise meaning of timestamps.
         """
         fact = Fact.parse(fact_str)
+
+        # default value if none found
+        if not fact.start_time:
+            fact.start_time = dt.datetime.now()
 
         if start_time == -1:
             fact.start_time = None


### PR DESCRIPTION
This is #491 again,  supplemented with "if the parsed fact has no start, use now".
Should be better than #492, 

fix #560 while keeping full backward compatibility with existing clients.

@jmberg the `10:00 meeting` activity can be entered either by tricking
(e.g. prepending a character: `.10:00 meeting`),
or (that's new) by using double dashes `--` as explicit missing times (see help).
Here That would be `-- -- 10:00 meeting`.

 @mwilck Thanks for your test case in #491. Now the time would not be ignored,
so in some sense #492 was not, while this one is fully backward compatible.
If a client wants "activity without range" (*not recommended at all*), 
it could just prepend `-- -- ` to the string:
![Screenshot_20200214_155923](https://user-images.githubusercontent.com/10962809/74541983-fc723380-4f42-11ea-8bb9-6fecfe160926.png)

![Screenshot_20200214_155643](https://user-images.githubusercontent.com/10962809/74541818-9f767d80-4f42-11ea-9f92-e5ef15f152a2.png)



