### PR TITLE
fix off-by-one bug for hamster export tsv

### DIFF
--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -153,6 +153,7 @@ class Storage(gobject.GObject):
         if isinstance(start, dt.hday) or isinstance(start, dt.date):
             range = dt.Range.from_start_end(start, end)
         else:
+            # workaround for https://github.com/projecthamster/hamster/pull/577
             range = dt.Range(start, end)
         dbus_range = to_dbus_range(range)
         return [from_dbus_fact_json(fact)

--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -150,7 +150,10 @@ class Storage(gobject.GObject):
            to boolean AND.
            Filter is applied to tags, categories, activity names and description
         """
-        range = dt.Range.from_start_end(start, end)
+        if isinstance(start, dt.hday) or isinstance(start, dt.date):
+            range = dt.Range.from_start_end(start, end)
+        else:
+            range = dt.Range(start, end)
         dbus_range = to_dbus_range(range)
         return [from_dbus_fact_json(fact)
                 for fact in self.conn.GetFactsJSON(dbus_range, search_terms)]


### PR DESCRIPTION
This PR is a workaround for a bug concerning the range.end in some date ranges (#576).

A better fix would address the issue in hamster.lib.datetime.Range.from_start_end(), but my attempts there created other problems. 