### PR TITLE
Use itstool instead of xml2po

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ https://snapcraft.io/hamster-snap
 ```bash
 sudo apt install gettext intltool python3-gi-cairo python3-distutils python3-dbus python3-xdg libglib2.0-dev
 # and for documentation
-sudo apt install gnome-doc-utils yelp
+sudo apt install itstool yelp
 ```
 
 ##### openSUSE
@@ -73,7 +73,7 @@ sudo apt install gnome-doc-utils yelp
 Leap-15.0 and Leap-15.1:
 ```bash
 sudo zypper install intltool python3-pyxdg python3-cairo python3-gobject-Gdk
-sudo zypper install gnome-doc-utils xml2po yelp
+sudo zypper install itstool yelp
 ```
 
 ##### RPM-based

--- a/help/Makefile.am
+++ b/help/Makefile.am
@@ -1,11 +1,8 @@
-include $(top_srcdir)/gnome-doc-utils.make
-dist-hook: doc-dist-hook
+@YELP_HELP_RULES@
 
-DOC_ID = hamster
-DOC_INCLUDES = legal.xml
-DOC_LINGUAS = cs da de el es fa fr gl hu pl pt_BR ro ru sl te zh_CN zh_HK zh_TW
+HELP_ID = hamster
 
-DOC_PAGES = \
+HELP_FILES = \
         backup.page \
         index.page \
         input.page \
@@ -13,4 +10,7 @@ DOC_PAGES = \
         merge.page \
         reports.page \
         statistics.page \
-        tracking.page
+        tracking.page \
+        legal.xml
+
+HELP_LINGUAS = cs da de el es fa fr gl hu pl pt_BR ro ru sl te zh_CN zh_HK zh_TW

--- a/help/Makefile.am
+++ b/help/Makefile.am
@@ -1,6 +1,7 @@
 @YELP_HELP_RULES@
 
 HELP_ID = hamster
+HELP_LINGUAS = cs da de el es fa fr gl hu pl pt_BR ro ru sl te zh_CN zh_HK zh_TW
 
 HELP_FILES = \
         backup.page \
@@ -12,5 +13,3 @@ HELP_FILES = \
         statistics.page \
         tracking.page \
         legal.xml
-
-HELP_LINGUAS = cs da de el es fa fr gl hu pl pt_BR ro ru sl te zh_CN zh_HK zh_TW

--- a/help/wscript
+++ b/help/wscript
@@ -34,7 +34,7 @@ def apply_mallard(self):
 	lst = self.to_list(bld.env["HELP_LINGUAS"])
 	cnode = self.path.find_dir("C")
 
-	pages = [p.name for p in cnode.ant_glob("*.page")]
+	pages = [p.name for p in cnode.ant_glob(["*.page", "*.xml"])]
 
 	# Check if the declared page list is consistent
 	declared_pages = self.to_list(bld.env["HELP_FILES"])
@@ -54,10 +54,10 @@ def apply_mallard(self):
 		    target=mo,
 		    )
 		for page in pages:
-			src = self.path.find_resource('C/%s' % page)
 			out = self.path.find_or_declare('%s/%s' % (lang, page))
+			src = self.path.find_resource('C/%s' % page)
 			bld(name='itstool', color='BLUE',
-			    rule='${ITSTOOL} ${ITSTOOLFLAGS} ${SRC} -o ${TGT}',
+			    rule='${ITSTOOL} -m ${SRC} -o ${TGT}',
 			    source=[mo, src],
 			    target=out,
 			    install_path=install_path(lang)
@@ -85,7 +85,6 @@ def configure(ctx):
 		ctx.find_program('msgfmt', var='MSGFMT')
 		ctx.find_program(lookfor, var='ITSTOOL')
 		ctx.env.docs = True
-		ctx.env.ITSTOOLFLAGS = '-m'
 	except ctx.errors.ConfigurationError:
 		Logs.warn("'{}' not found; documentation build disabled".format(lookfor))
 		ctx.env.docs = False

--- a/help/wscript
+++ b/help/wscript
@@ -9,50 +9,56 @@ import os
 from waflib import Logs, TaskGen
 
 def _read_makefile_am(filename):
-	"read a Makefile.am file for DOC_* variable definitions, return a dict"
+	"read a Makefile.am file for HELP_* variable definitions, return a dict"
 	varstring = open(filename).read()
 	varstring = varstring.replace("\\\n", " ")
-	varlines = [L for L in varstring.splitlines() if L.startswith("DOC")]
+	varlines = [L for L in varstring.splitlines() if L.startswith("HELP")]
 	return dict(tuple(map(str.strip, var.split("=", 1))) for var in varlines)
 
 def init_mallard(self):
 	mf_am = self.path.find_resource(self.variable_definitions)
-	DOC_VAR = _read_makefile_am(mf_am.abspath())
+	HELP_VAR = _read_makefile_am(mf_am.abspath())
 
-	require_vars = "DOC_ID DOC_LINGUAS DOC_PAGES".split()
-	have_vars = set(var for var in DOC_VAR if DOC_VAR[var])
+	require_vars = "HELP_ID HELP_LINGUAS HELP_FILES".split()
+	have_vars = set(var for var in HELP_VAR if HELP_VAR[var])
 	missing_vars = set(require_vars).difference(have_vars)
 	if missing_vars:
-		print("Missing DOC variable declarations in {}:".format(mf_am.abspath()))
+		print("Missing HELP variable declarations in {}:".format(mf_am.abspath()))
 		print("\n".join(missing_vars))
 
-	self.bld.env.update(DOC_VAR)
+	self.bld.env.update(HELP_VAR)
 	self.default_install_path='${PREFIX}/share/help'
 
 def apply_mallard(self):
 	bld = self.bld
-	lst = self.to_list(bld.env["DOC_LINGUAS"])
+	lst = self.to_list(bld.env["HELP_LINGUAS"])
 	cnode = self.path.find_dir("C")
 
 	pages = [p.name for p in cnode.ant_glob("*.page")]
 
 	# Check if the declared page list is consistent
-	declared_pages = self.to_list(bld.env["DOC_PAGES"])
+	declared_pages = self.to_list(bld.env["HELP_FILES"])
 	missing_pages = set(pages).difference(declared_pages)
 	if missing_pages:
 		print("Warning: Some pages not declared:")
 		print("\n".join(missing_pages))
 
-	install_path = lambda lang: os.path.join(bld.env.DATADIR, "help", lang, "${DOC_ID}")
+	install_path = lambda lang: os.path.join(bld.env.DATADIR, "help", lang, "${HELP_ID}")
 
 	for lang in lst:
 		node = self.path.find_resource("%s/%s.po" % (lang, lang))
+		mo = self.path.find_or_declare("%s/%s.mo" % (lang, lang))
+		bld(name='msgfmt', color='BLUE',
+		    rule='${MSGFMT} ${SRC} -o ${TGT}',
+		    source=node,
+		    target=mo,
+		    )
 		for page in pages:
-			out = self.path.find_or_declare('%s/%s' % (lang, page))
 			src = self.path.find_resource('C/%s' % page)
-			bld(name='xml2po', color='BLUE',
-			    rule='${XML2PO} ${XML2POFLAGS} ${SRC} > ${TGT}',
-			    source=[node, src],
+			out = self.path.find_or_declare('%s/%s' % (lang, page))
+			bld(name='itstool', color='BLUE',
+			    rule='${ITSTOOL} ${ITSTOOLFLAGS} ${SRC} -o ${TGT}',
+			    source=[mo, src],
 			    target=out,
 			    install_path=install_path(lang)
 			    )
@@ -74,11 +80,12 @@ TaskGen.after('init_mallard')(apply_mallard)
 
 
 def configure(ctx):
-	lookfor = "xml2po"
+	lookfor = "itstool"
 	try:
-		ctx.find_program(lookfor, var='XML2PO')
+		ctx.find_program('msgfmt', var='MSGFMT')
+		ctx.find_program(lookfor, var='ITSTOOL')
 		ctx.env.docs = True
-		ctx.env.XML2POFLAGS = '-mmallard -p'
+		ctx.env.ITSTOOLFLAGS = '-m'
 	except ctx.errors.ConfigurationError:
 		Logs.warn("'{}' not found; documentation build disabled".format(lookfor))
 		ctx.env.docs = False


### PR DESCRIPTION
xml2po is deprecated and itstool from Yelp is recommended as its
replacement.

The code in wscript that handles this looks at the Makefile.am file to
figure out what pages and languages to compile. The Makefile is not
actually executed in this process, but is presumably present to allow
manually compiling the helpfiles too. This makefile is adapted to the
style used by itstool, changing DOC_ variables to HELP_ variables.

This also moves legal.xml from DOC_INCLUDES to HELP_PAGES, to make sure
it is still processed. At the same time, the python code is modified to
also process .xml files (instead of just .page files). Note that before
this commit, legal.xml would be processed by the Makefile, but not by
the wscript file, which is now fixed.

Whereas xml2po (when run with -p) would combine an XML file and a .po
file and produce a translated xml file, itstool does the same but with a
.mo file. This means that the .po file must be compiled into a .mo
beforehand, which done with an added msgfmt rule.

This fixes #583.
