### PR TITLE
Daily summary totals added to Overview screen

### DIFF
--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -52,6 +52,8 @@ class TotalFact(Fact):
    of Fact.
    A TotalFact doesn't have a meaningful  start and an end, but a 
    total duration (delta).
+   FIXME: Ideally, we should have a common parent for Fact and Total Fact
+   so we don't need to have nonsensical start and end properties here.
    """
    def __init__(self, activity, duration):
         super().__init__(activity=activity, start=dt.datetime.now(), end=dt.datetime.now())


### PR DESCRIPTION
While migrating to Ubuntu 20.04 from 16.04 I noticed that the current version of Hamster doesn't provide daily totals in the Overview screen. This PR introduces a "Total" row after each day. These rows can't be selected (clicked) and navigation with the cursor keys skip them. These rows are not included when exporting the tasks.

Here you can find a screenshot of how the modifications look like: https://ibb.co/GFPv2Sj

Please note that I'm not really familiar with Python, so please let me know if there is something in my changes that can be improved.