### PR TITLE
Start adding release notes for 3.0.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## Changes in 3.0.3 (unreleased)
+
+* Daily summary totals added to Overview screen (PR 596)
+
 ## Changes in 3.0.2
 
 * Switch from deprecated xml2po to itstool for translating help files


### PR DESCRIPTION
Adding a section for the next release, it makes it easier to get an overview of upcoming changes and once someone want to release, they don't have to feel blocked by having to go through commit logs / PRs etc.

CC: @matthijskooijman