### PR TITLE
FactTree: don't reset y position in set_facts()

### DIFF
--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -487,10 +487,9 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         self.facts = [fact.copy(id=fact.id) for fact in facts]
         del facts  # make sure facts is not used by inadvertance below.
 
-        self.y = 0
         self.hover_fact = None
         if self.vadjustment:
-            self.vadjustment.set_value(0)
+            self.vadjustment.set_value(self.y)
 
         if self.facts:
             start = self.facts[0].date


### PR DESCRIPTION
set_facts() is called every minute to update the time of the current
activitiy. If the y position is reset to 0 in set_facts(), this causes
the fact list to be scrolled to the top once a minute, irritating users.

Fix it by simply not resetting the y position. This Resolves #594.