### PR TITLE
Adding activities in retrospect is very hard

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## Changes in 3.0.3 (unreleased)
+
+* Fixed Adding activities in retrospect is very hard (issue 627)
+
 ## Changes in 3.0.2
 
 * Switch from deprecated xml2po to itstool for translating help files


### PR DESCRIPTION
Update edit_activity.py to components in the form be aware of selected date

For activity in cmdline: `some activity` (without date and time)
- checked incrementing and decrementing day
- checked date picker
- checked date picker set to one date and cmdline on another date (cmdline has higher priority)

This fixes #627 Adding activities in retrospect is very hard.