### PR TITLE
RangePick: Fix issue with range picker popup not opening

### DIFF
--- a/src/hamster/widgets/dates.py
+++ b/src/hamster/widgets/dates.py
@@ -111,7 +111,6 @@ class RangePick(gtk.ToggleButton):
 
         self._ui.connect_signals(self)
         self.connect("destroy", self.on_destroy)
-        self._hiding = False
 
     def on_destroy(self, window):
         self.popup.destroy()
@@ -120,12 +119,6 @@ class RangePick(gtk.ToggleButton):
 
     def on_toggle(self, button):
         if self.get_active():
-            if self._hiding:
-                self._hiding = False
-                self.set_active(False)
-                return
-
-
             self.show()
         else:
             self.hide()
@@ -195,7 +188,7 @@ class RangePick(gtk.ToggleButton):
         button_w, button_h = self.get_allocation().width, self.get_allocation().height
         # avoid double-toggling when focus goes from window to the toggle button
         if 0 <= x <= button_w and 0 <= y <= button_h:
-            self._hiding = True
+            return
 
         self.set_active(False)
 


### PR DESCRIPTION
This popup is toggled using a button in the top bar of the overview
window. There is some code in the `on_focus_out` event handler so the
popup hides when it loses focus.

On some systems (observed on Debian Buster), the `on_focus_out` handler
seems to trigger immediately after the popup is shown, causing it to be
hidden again immediately, as reported in #639.

There is also some code in `on_focus_out` that detects when the focus is
lost because the button was clicked, to prevent a situation where
`on_focus_out` hides the popup and then the button click shows it again
immediately.

Previously, in this situation `on_focus_out` would still hide the popup,
but then prevent the next button click from showing it again. With this
commit, this is reversed: `on_focus_out` does not hide the popup,
instead relying on the button click to hide it instead.

This simplifies this special case a bit and ensures that the behavior
from #639 no longer causes a problem (since the extra `on_focus_out`
triggered by the initial click on the button now no longer hides the
popup).

This fixes #639.