### PR TITLE
Fix links to screenshots in appstream file

### DIFF
--- a/data/org.gnome.Hamster.GUI.metainfo.xml
+++ b/data/org.gnome.Hamster.GUI.metainfo.xml
@@ -35,11 +35,11 @@
   <screenshots>
     <screenshot type="default">
       <caption>The overview window</caption>
-      <image>https://github.com/projecthamster/hamster/blob/master/screenshot.png</image>
+      <image>https://raw.githubusercontent.com/projecthamster/hamster/master/screenshot.png</image>
     </screenshot>
     <screenshot>
       <caption>The overview window with statistics</caption>
-      <image>https://github.com/projecthamster/hamster/blob/master/data/screenshots/overview2.png</image>
+      <image>https://raw.githubusercontent.com/projecthamster/hamster/master/data/screenshots/overview2.png</image>
     </screenshot>
   </screenshots>
   ​<translation type="gettext">hamster</translation>


### PR DESCRIPTION
User *bigon* reported: "It looks like the appstream file is not pointing
to the png of the screenshots directly but to an html page" and provided
the links in this PR.

Fixes #641.
