### PR TITLE
Simplify Rangepick widget to fix issues on Debian Buster

### DIFF
--- a/data/date_range.ui
+++ b/data/date_range.ui
@@ -2,14 +2,8 @@
 <!-- Generated with glade 3.16.1 -->
 <interface>
   <requires lib="gtk+" version="3.2"/>
-  <object class="GtkWindow" id="range_popup">
+  <object class="GtkPopover" id="range_popup">
     <property name="can_focus">False</property>
-    <property name="resizable">False</property>
-    <property name="window_position">mouse</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="skip_pager_hint">True</property>
-    <property name="decorated">False</property>
     <child>
       <object class="GtkFrame" id="frame1">
         <property name="visible">True</property>

--- a/src/hamster/widgets/dates.py
+++ b/src/hamster/widgets/dates.py
@@ -79,7 +79,7 @@ class Calendar():
         return getattr(self.widget, name)
 
 
-class RangePick(gtk.ToggleButton):
+class RangePick(gtk.MenuButton):
     """ a text entry widget with calendar popup"""
     __gsignals__ = {
         # day|week|month|manual, start, end
@@ -92,8 +92,9 @@ class RangePick(gtk.ToggleButton):
 
         self._ui = load_ui_file("date_range.ui")
 
-        self.popup = self.get_widget("range_popup")
-        self.popup.set_relative_to(self)
+        popup = self.get_widget("range_popup")
+        popup.connect("show", self.on_show)
+        self.set_popover(popup)
 
         self.today = today
 
@@ -107,23 +108,7 @@ class RangePick(gtk.ToggleButton):
         self.start_date, self.end_date = None, None
         self.current_range = None
 
-        self.popup.connect("closed", self.on_closed)
-        self.connect("toggled", self.on_toggle)
-
         self._ui.connect_signals(self)
-        self.connect("destroy", self.on_destroy)
-
-    def on_destroy(self, window):
-        self.popup.destroy()
-        self.popup = None
-        self._ui = None
-
-    def on_toggle(self, button):
-        if self.get_active():
-            self.show()
-        else:
-            self.hide()
-
 
     def set_range(self, start_date, end_date=None):
         end_date = end_date or start_date
@@ -136,7 +121,7 @@ class RangePick(gtk.ToggleButton):
     def emit_range(self, range, start, end):
         self.set_range(start, end)
         self.emit("range-selected", range, start, end)
-        self.hide()
+        self.set_active(False)
 
 
     def prev_range(self):
@@ -184,15 +169,7 @@ class RangePick(gtk.ToggleButton):
         return self._ui.get_object(name)
 
 
-    def on_closed(self, popup):
-        self.set_active(False)
-
-
-    def hide(self):
-        self.set_active(False)
-        self.popup.hide()
-
-    def show(self):
+    def on_show(self, user_data):
         self.get_widget("day_preview").set_text(stuff.format_range(self.today, self.today))
         self.get_widget("week_preview").set_text(stuff.format_range(*stuff.week(self.today)))
         self.get_widget("month_preview").set_text(stuff.format_range(*stuff.month(self.today)))
@@ -205,9 +182,7 @@ class RangePick(gtk.ToggleButton):
         end_cal.select_month(self.end_date.month - 1, self.end_date.year)
         end_cal.select_day(self.end_date.day)
 
-        self.popup.popup()
         self.get_widget("day").grab_focus()
-        self.set_active(True)
 
 
     def on_day_clicked(self, button):


### PR DESCRIPTION
This simplifies the Rangepick widget by using `gtk.Popover` and `gtk.MenuButton`, conveniently handle a lot of the boilerplate of hiding and showing the popup automatically. This also allows removing some problematic code, fixing #639 and because no separate window is created anymore, this indirectly also fixes #645.

This slightly changes the looks of the popup, previously it was:

![image](https://user-images.githubusercontent.com/194491/99690047-f851e400-2a87-11eb-9434-75f9b76242e6.png)

Now it is:

![image](https://user-images.githubusercontent.com/194491/99689938-dc4e4280-2a87-11eb-9028-479a25b3e2a1.png)

Note the "arrow", border and slightly different positioning of the popup.

One downside of using a Popover is that it is a widget, rather than an window, so at least on X11, it cannot extend outside of the containing window, but this is probably not a problem in practice (this limitation does not seem to exist on Wayland, see https://gitlab.gnome.org/GNOME/gtk/-/issues/543).

This PR supersedes #643 and as far as I'm concerned, is how we should be fixing these issues.

@taniwallach, would you be so kind to give this PR a final test on your two machines?

@others, anyone want to give this PR a technical review, so we can get it merged?