### PR TITLE
Reset position in FactTree only when needed

### DIFF
--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -523,19 +523,19 @@ class Overview(Controller):
         if event.keyval == gdk.KEY_Escape:
             self.close_window()
 
-    def find_facts(self):
+    def find_facts(self, scroll_to_top=False):
         start, end = self.header_bar.range_pick.get_range()
         search_active = self.header_bar.search_button.get_active()
         search = "" if not search_active else self.filter_entry.get_text()
         search = "%s*" % search if search else "" # search anywhere
         self.facts = self.storage.get_facts(start, end, search_terms=search)
-        self.fact_tree.set_facts(self.facts)
+        self.fact_tree.set_facts(self.facts, scroll_to_top=scroll_to_top)
         self.totals.set_facts(self.facts)
         self.header_bar.stop_button.set_sensitive(
             self.facts and not self.facts[-1].end_time)
 
     def on_range_selected(self, button, range_type, start, end):
-        self.find_facts()
+        self.find_facts(scroll_to_top=True)
 
     def on_search_changed(self, entry):
         if entry.get_text():
@@ -544,7 +544,7 @@ class Overview(Controller):
         else:
             self.filter_entry.set_icon_from_icon_name(gtk.EntryIconPosition.SECONDARY,
                                                       None)
-        self.find_facts()
+        self.find_facts(scroll_to_top=True)
 
     def on_search_icon_press(self, entry, position, event):
         if position == gtk.EntryIconPosition.SECONDARY:

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -481,16 +481,18 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         self.vadjustment.connect("value_changed", self.on_scroll_value_changed)
         self.set_size_request(500, 300)
 
-    def set_facts(self, facts):
+    def set_facts(self, facts, scroll_to_top=False):
         # FactTree adds attributes to its facts. isolate these side effects
         # copy the id too; most of the checks are based on id here.
         self.facts = [fact.copy(id=fact.id) for fact in facts]
         del facts  # make sure facts is not used by inadvertance below.
 
-        self.y = 0
+        # If we get an entirely new set of facts, scroll back to the top
+        if scroll_to_top:
+            self.y = 0
         self.hover_fact = None
         if self.vadjustment:
-            self.vadjustment.set_value(0)
+            self.vadjustment.set_value(self.y)
 
         if self.facts:
             start = self.facts[0].date


### PR DESCRIPTION
Right now FactTree.set_facts() is always resetting the position of the
view, bringing the user back to the top but this function is called
regularly to update with the latest data even when the user has not
changed anything in the selection widget... which is really annoying
when you are reviewing the list of facts.

Let's distinguish between both cases with a "reset=True" attribute that
we use when we generate an entirely new set of facts to be displayed.

This makes #623 obsolete. Thanks to @mwilck for the initial analysis.

Fixes #594