### PR TITLE
Add keyword entry to .desktop file

### DIFF
--- a/data/org.gnome.Hamster.GUI.desktop.in
+++ b/data/org.gnome.Hamster.GUI.desktop.in
@@ -8,6 +8,7 @@ Icon=org.gnome.Hamster.GUI
 DBusActivatable=true
 Exec=@BINDIR@/hamster
 Categories=GNOME;GTK;Utility;
+Keywords=time tracking;time-log;personal productivity
 Actions=overview;add;
 
 [Desktop Action overview]


### PR DESCRIPTION
The Debian package checker, lintian, complains about the .desktop file
missing a "keyword" entry.

Fixes #629