### PR TITLE
Remove dark bars for empty days in overview (take 2)

### DIFF
--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -514,7 +514,8 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         days = []
         for i in range((end - start).days + 1):
             current_date = start + dt.timedelta(days=i)
-            days.append((current_date, by_date[current_date]))
+            if current_date in by_date:
+                days.append((current_date, by_date[current_date]))
 
         self.days = days
 
@@ -553,11 +554,7 @@ class FactTree(graphics.Scene, gtk.Scrollable):
                 height += fact.height
 
             height += self.day_padding
-
-            if not facts:
-                height = 10
-            else:
-                height = max(height, 60)
+            height = max(height, 60)
 
             pos.append(y)
             heights.append(height)
@@ -635,23 +632,6 @@ class FactTree(graphics.Scene, gtk.Scrollable):
         for rec in self.visible_range:
             g.save_context()
             g.translate(0, rec['y'])
-
-            if not rec['facts']:
-                "do a collapsy thing"
-                g.rectangle(0, 0, self.width, 10)
-                g.clip()
-                g.rectangle(0, 0, self.width, 10)
-                none_bg_color = self.colors.mix(colors["normal_bg"], colors["normal"], 0.75)
-                g.fill(none_bg_color)
-
-                # line, useful to separate consecutive days with no activity
-                g.move_to(0, 0)
-                g.line_to(self.width, 0)
-                none_stroke_color = self.colors.mix(colors["normal_bg"], colors["normal"], 0.25)
-                g.stroke(none_stroke_color)
-                g.restore_context()
-                continue
-
             g.set_color(colors["normal"])
             self.date_label.show(g, rec['day'].strftime("%A\n%b %d"))
 


### PR DESCRIPTION
The overview currently has dark bars for days with no recorded facts. These are considered unsightly by some (eg. #615, and me too). The behaviour is inconsistent because empty days at the start and end of the date range are not highlighted whereas intermediate empty days are.

This PR completely skips over empty days in the selected date range.

(This is a revival of #619, already approved by mwilk. I promise to be more patient this time.)