### PR TITLE
Fix tag popup displaying by setting parent.

### DIFF
--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -79,8 +79,7 @@ class CustomFactController(Controller):
 
         self.start_time = widgets.TimeInput(parent=self.get_widget("start time box"))
 
-        self.tags_entry = widgets.TagsEntry()
-        self.get_widget("tags box").add(self.tags_entry)
+        self.tags_entry = widgets.TagsEntry(parent=self.get_widget("tags box"))
 
         self.save_button = self.get_widget("save_button")
 

--- a/src/hamster/preferences.py
+++ b/src/hamster/preferences.py
@@ -133,8 +133,7 @@ class PreferencesEditor(Controller):
             (selection, selection.connect('changed', self.category_changed_cb, self.category_store))
         ])
 
-        self.day_start = widgets.TimeInput(dt.time(5,30))
-        self.get_widget("day_start_placeholder").add(self.day_start)
+        self.day_start = widgets.TimeInput(dt.time(5,30), parent=self.get_widget("day_start_placeholder"))
 
         self.load_config()
 

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -203,7 +203,7 @@ class CompleteTree(graphics.Scene):
 
 
 class CmdLineEntry(gtk.Entry):
-    def __init__(self, updating=True, **kwargs):
+    def __init__(self, **kwargs):
         gtk.Entry.__init__(self, **kwargs)
 
         # default day for times without date

--- a/src/hamster/widgets/activityentry.py
+++ b/src/hamster/widgets/activityentry.py
@@ -203,8 +203,8 @@ class CompleteTree(graphics.Scene):
 
 
 class CmdLineEntry(gtk.Entry):
-    def __init__(self, **kwargs):
-        gtk.Entry.__init__(self, **kwargs)
+    def __init__(self, *, parent, **kwargs):
+        gtk.Entry.__init__(self, parent=parent, **kwargs)
 
         # default day for times without date
         self.default_day = None

--- a/src/hamster/widgets/tags.py
+++ b/src/hamster/widgets/tags.py
@@ -32,13 +32,16 @@ class TagsEntry(gtk.Entry):
         'tags-selected': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, ()),
     }
 
-    def __init__(self):
-        gtk.Entry.__init__(self)
+    def __init__(self, *, parent):
+        gtk.Entry.__init__(self, parent=parent)
         self.ac_tags = None  # "autocomplete" tags
         self.filter = None # currently applied filter string
         self.filter_tags = [] #filtered tags
 
         self.popup = gtk.Window(type = gtk.WindowType.POPUP)
+        self.popup.set_attached_to(self)
+        self.popup.set_transient_for(self.get_ancestor(gtk.Window))
+
         self.scroll_box = gtk.ScrolledWindow()
         self.scroll_box.set_shadow_type(gtk.ShadowType.IN)
         self.scroll_box.set_policy(gtk.PolicyType.NEVER, gtk.PolicyType.AUTOMATIC)

--- a/src/hamster/widgets/timeinput.py
+++ b/src/hamster/widgets/timeinput.py
@@ -33,8 +33,8 @@ class TimeInput(gtk.Entry):
     }
 
 
-    def __init__(self, time=None, start_time=None, **kwargs):
-        gtk.Entry.__init__(self, **kwargs)
+    def __init__(self, time=None, start_time=None, *, parent, **kwargs):
+        gtk.Entry.__init__(self, parent=parent, **kwargs)
         self.news = False
         self.set_width_chars(7) #7 is like 11:24pm
 


### PR DESCRIPTION
Similar to other recent wayland popup issues.

Without setting parent the tag popup opens and immediately closes. Previously it only meant that popup doesn't stay opened, but recently it started interfering with focus making it difficult to type in text.

Tested on ArchLinux with GTK 3.24, Gnome desktop and wayland.