### PR TITLE
Simplify parsing of facts with a clear tag barrier

### DIFF
--- a/help/C/input.page
+++ b/help/C/input.page
@@ -11,18 +11,18 @@
     To start tracking, press the <gui style="button">+</gui> button,
     type in the activity name in the entry,
     and hit the <key>Enter</key> key.
-    To specify more detail on the fly, use this syntax: 
-    `time_info activity name @category,, some description #tag #other tag with spaces`.
+    To specify more detail on the fly, use this syntax:
+    `time_info activity name@category, some description #tag #other tag with spaces`.
 </p>
 
 <steps>
     <item><p>Specify specific times as `13:10-13:45`, and "started 5 minutes ago" as `-5`.</p></item>
     <item><p>Next comes the activity name</p></item>
     <item><p>Place the category after the activity name, and start it with an at sign `@`, e.g. `@garden`</p></item>
-    <item><p>If you want to add a description, add a double comma `,,`.</p></item>
-    <item><p>The description is just freeform text immediately after the double comma, and runs until the end of the string or until the beginning of tags.</p></item>
+    <item><p>If you want to add a description, add a comma `,`.</p></item>
+    <item><p>The description is just freeform text immediately after the comma, and runs until the end of the string or until the beginning of tags.</p></item>
     <item><p>Place tags at the end, and start each tag with a hash mark `#`.</p></item>
-    <item><p>A double comma `,,` can also be placed to indicate the beginning of tags. Otherwise any `#` in the activity, category or description would be interpreted as a starting a tag.</p></item>
+    <item><p>A comma `,` can also be placed to indicate the beginning of tags. Otherwise any `#` in the activity, category or description would be interpreted as a starting a tag.</p></item>
 </steps>
 
 <p>
@@ -33,14 +33,14 @@
     <p>Forgot to note the important act of watering flowers over lunch.</p>
 </example>
 <example>
-    <code>tomatoes@garden,, digging holes</code>
+    <code>tomatoes@garden, digging holes</code>
     <p>
         Need more tomatoes in the garden. Digging holes is purely informational,
         so added it as a description.
     </p>
 </example>
 <example>
-    <code>-7 existentialism,, thinking about the vastness of the universe</code>
+    <code>-7 existentialism, thinking about the vastness of the universe</code>
     <p>
         Corrected information by informing application that I've been
         doing something else for the last seven minutes.
@@ -52,14 +52,14 @@
     <list>
         <item>
             <p>Relative times work both for <var>start</var> and <var>end</var>,
-            provided they are preceded by an explicit sign, 
+            provided they are preceded by an explicit sign,
             and <em>separated by a space</em>.</p>
             <p><code>-30 -10</code> means started 30 minutes ago and stopped 10 minutes ago.</p>
             <p><code>-5 +30</code> means started 5 minutes ago and will stop in 30 minutes
             (duration of 35 minutes).</p>
         </item>
         <item>
-            <p>Duration can be given instead of <var>end</var>, 
+            <p>Duration can be given instead of <var>end</var>,
             as 1, 2 or 3 digits without any sign.</p>
             <p><code>-50 30</code> means started 50 minutes ago and lasted 30 minutes
             (so it ended 20 minutes ago).</p>

--- a/help/C/input.page
+++ b/help/C/input.page
@@ -12,18 +12,23 @@
     type in the activity name in the entry,
     and hit the <key>Enter</key> key.
     To specify more detail on the fly, use this syntax:
-    `time_info activity name@category, some description #tag #other tag with spaces`.
+    `time_info activity name@category, some description, #tag #other tag with spaces`.
 </p>
 
 <steps>
     <item><p>Specify specific times as `13:10-13:45`, and "started 5 minutes ago" as `-5`.</p></item>
     <item><p>Next comes the activity name</p></item>
     <item><p>Place the category after the activity name, and start it with an at sign `@`, e.g. `@garden`</p></item>
-    <item><p>If you want to add a description, add a comma `,`.</p></item>
+    <item><p>If you want to add a description and/or tags, add a comma `,`.</p></item>
     <item><p>The description is just freeform text immediately after the comma, and runs until the end of the string or until the beginning of tags.</p></item>
-    <item><p>Place tags at the end, and start each tag with a hash mark `#`.</p></item>
-    <item><p>A comma `,` can also be placed to indicate the beginning of tags. Otherwise any `#` in the activity, category or description would be interpreted as a starting a tag.</p></item>
+    <item><p>Place tags at the end right after a comma, and start each tag with a hash mark `#`.</p></item>
 </steps>
+
+<p>Note that you can embed single-word tags in the description just by
+prepending a hash to any word. Note that sequences of alphanumeric
+characters that start with a digit are not considered as words so if you
+use <code>Fix bug #123</code> as your description, the hash will be kept
+and there will be no supplementary tag named <code>123</code>.</p>
 
 <p>
     A few examples:
@@ -44,6 +49,14 @@
     <p>
         Corrected information by informing application that I've been
         doing something else for the last seven minutes.
+    </p>
+</example>
+<example>
+    <code>Hamster@Software, doing some #reviews of pull requests</code>
+    <code>Hamster@Software, doing some reviews of pull requests, #reviews</code>
+    <p>
+	Those two syntaxes are equivalent. Single word tags can be embedded in the
+	description (except on the first word).
     </p>
 </example>
 

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -189,17 +189,8 @@ class Fact(object):
             res += ', '
             res += self.description
 
-        if ('#' in self.activity
-            or '#' in self.category
-            or '#' in self.description
-           ):
-            # need a tag barrier
-            res += ", "
-
         if self.tags:
-            # double comma is a left barrier for tags,
-            # which is useful only if previous fields contain a hash
-            res += " %s" % " ".join("#%s" % tag for tag in self.tags)
+            res += ", %s" % " ".join("#%s" % tag for tag in self.tags)
         return res
 
     def serialized(self, range_pos="head", default_day=None):

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -186,7 +186,7 @@ class Fact(object):
             res += "@%s" % self.category
 
         if self.description:
-            res += ',, '
+            res += ', '
             res += self.description
 
         if ('#' in self.activity
@@ -194,7 +194,7 @@ class Fact(object):
             or '#' in self.description
            ):
             # need a tag barrier
-            res += ",, "
+            res += ", "
 
         if self.tags:
             # double comma is a left barrier for tags,

--- a/src/hamster/lib/fact.py
+++ b/src/hamster/lib/fact.py
@@ -14,7 +14,7 @@ import calendar
 from copy import deepcopy
 
 from hamster.lib import datetime as dt
-from hamster.lib.parsing import parse_fact
+from hamster.lib.parsing import parse_fact, get_tags_from_description
 
 
 class FactError(Exception):
@@ -190,7 +190,13 @@ class Fact(object):
             res += self.description
 
         if self.tags:
-            res += ", %s" % " ".join("#%s" % tag for tag in self.tags)
+            # Don't duplicate tags that are already in the description
+            seen_tags = get_tags_from_description(self.description)
+            remaining_tags = [
+                tag for tag in self.tags if tag not in seen_tags
+            ]
+            if remaining_tags:
+                res += ", %s" % " ".join("#%s" % tag for tag in remaining_tags)
         return res
 
     def serialized(self, range_pos="head", default_day=None):

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -33,6 +33,11 @@ tags_separator = re.compile(r"""
     (?=\#)      # hash character (start of first tag, doesn't consume it)
 """, flags=re.VERBOSE)
 
+description_separator = re.compile(r"""
+    ,+          # 1 or more commas
+    \s*         # maybe spaces
+""", flags=re.VERBOSE)
+
 
 def get_tags_from_description(description):
     return list(re.findall(tags_in_description, description))
@@ -73,7 +78,9 @@ def parse_fact(text, range_pos="head", default_day=None, ref="now"):
 
     # description
     # first look for comma (description hard left boundary)
-    head, sep, description = remaining_text.partition(",")
+    split = re.split(description_separator, remaining_text, 1)
+    head = split[0]
+    description = split[1] if len(split) > 1 else ""
     # Extract tags from description, put them before other tags
     tags = get_tags_from_description(description) + tags
     res["description"] = description.strip()

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -37,7 +37,7 @@ def parse_fact(text, range_pos="head", default_day=None, ref="now"):
     Returns found fields as a dict.
 
     Tentative syntax (not accurate):
-    start [- end_time] activity[@category][,, description][,,]{ #tag}
+    start [- end_time] activity[@category][, description][,]{ #tag}
     According to the legacy tests, # were allowed in the description
     """
 
@@ -64,7 +64,7 @@ def parse_fact(text, range_pos="head", default_day=None, ref="now"):
         # especially the tags barrier
         m = re.search(tags_separator, remaining_text)
         remaining_text = remaining_text[:m.start()]
-        if m.group(1) == ",,":
+        if m.group(1) == ",":
             # tags  barrier found
             break
 
@@ -83,8 +83,8 @@ def parse_fact(text, range_pos="head", default_day=None, ref="now"):
     res["tags"] = list(reversed(tags))
 
     # description
-    # first look for double comma (description hard left boundary)
-    head, sep, description = remaining_text.partition(",,")
+    # first look for comma (description hard left boundary)
+    head, sep, description = remaining_text.partition(",")
     res["description"] = description.strip()
     remaining_text = head.strip()
 

--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -7,8 +7,7 @@ from hamster.lib import datetime as dt
 
 
 # separator between times and activity
-ACTIVITY_SEPARATOR = "\s+"
-
+activity_separator = r"\s+"
 
 # match #tag followed by any space or # that will be ignored
 # tag must not contain '#' or ','
@@ -62,8 +61,8 @@ def parse_fact(text, range_pos="head", default_day=None, ref="now"):
     # datetimes
     # force at least a space to avoid matching 10.00@cat
     (start, end), remaining_text = dt.Range.parse(text, position=range_pos,
-                                                   separator=ACTIVITY_SEPARATOR,
-                                                   default_day=default_day)
+                                                  separator=activity_separator,
+                                                  default_day=default_day)
     res["start_time"] = start
     res["end_time"] = end
 

--- a/tests/test_stuff.py
+++ b/tests/test_stuff.py
@@ -103,6 +103,17 @@ class TestFactParsing(unittest.TestCase):
         assert activity.start_time is None
         assert activity.end_time is None
 
+    def test_multiple_tags_separated_with_commas(self):
+        activity = Fact.parse("devel, fun times, #bugs, #pr, #hamster")
+        self.assertEqual(set(activity.tags),
+                         set(["bugs", "pr", "hamster"]))
+
+    def test_tags_without_description(self):
+        activity = Fact.parse("case, #tag1 #tag2")
+        self.assertEqual(activity.activity, "case")
+        self.assertEqual(activity.description, "")
+        self.assertEqual(set(activity.tags), set(["tag1", "tag2"]))
+
     def test_full(self):
         # plain activity name
         activity = Fact.parse(
@@ -133,7 +144,7 @@ class TestFactParsing(unittest.TestCase):
         self.assertEqual(fact3.tags, ["changed"])
 
     def test_comparison(self):
-        fact1 = Fact.parse("12:25-13:25 case@cat, description #tag #bäg")
+        fact1 = Fact.parse("12:25-13:25 case@cat, description, #tag #bäg")
         fact2 = fact1.copy()
         self.assertEqual(fact1, fact2)
         fact2 = fact1.copy()
@@ -165,26 +176,27 @@ class TestFactParsing(unittest.TestCase):
         fact = Fact.parse("12:25-13:25 10.0@ABC, Two Words #tag #bäg")
         self.assertEqual(fact.activity, "10.0")
         self.assertEqual(fact.category, "ABC")
-        self.assertEqual(fact.description, "Two Words")
         # should not pick up a time here
         fact = Fact.parse("10.00@ABC, Two Words #tag #bäg")
         self.assertEqual(fact.activity, "10.00")
         self.assertEqual(fact.category, "ABC")
-        self.assertEqual(fact.description, "Two Words")
 
-    def test_spaces(self):
-        # cf. issue #114
-        fact = Fact.parse("11:00 12:00 BPC-261 - Task title@Project#code")
+    def test_activity_with_spaces(self):
+        fact = Fact.parse("11:00 12:00 BPC-261 - Task title@Project")
         self.assertEqual(fact.activity, "BPC-261 - Task title")
         self.assertEqual(fact.category, "Project")
         self.assertEqual(fact.description, "")
-        self.assertEqual(fact.tags, ["code"])
-        # space between category and tag
-        fact2 = Fact.parse("11:00 12:00 BPC-261 - Task title@Project #code")
-        self.assertEqual(fact.serialized(), fact2.serialized())
-        # empty fact
-        fact3 = Fact()
-        self.assertEqual(fact3.serialized(), "")
+        self.assertEqual(fact.tags, [])
+
+    def test_activity_and_category_with_hash_and_space(self):
+        fact = Fact.parse("11:00 12:00 Activity #1@Category #2")
+        self.assertEqual(fact.activity, "Activity #1")
+        self.assertEqual(fact.category, "Category #2")
+        self.assertEqual(fact.description, "")
+
+    def test_serialization_of_an_empty_fact(self):
+        fact = Fact()
+        self.assertEqual(fact.serialized(), "")
 
     def test_commas(self):
         fact = Fact.parse("11:00 12:00 activity@category, description, with comma")
@@ -255,13 +267,13 @@ class TestFactParsing(unittest.TestCase):
                                 for range_pos in ("head", "tail"):
                                     fact_str = fact.serialized(range_pos=range_pos)
                                     parsed = Fact.parse(fact_str, range_pos=range_pos)
-                                    self.assertEqual(fact, parsed)
                                     self.assertEqual(parsed.range.start, fact.range.start)
                                     self.assertEqual(parsed.range.end, fact.range.end)
                                     self.assertEqual(parsed.activity, fact.activity)
                                     self.assertEqual(parsed.category, fact.category)
                                     self.assertEqual(parsed.description, fact.description)
                                     self.assertEqual(parsed.tags, fact.tags)
+                                    self.assertEqual(fact, parsed)
 
 
 class TestDatetime(unittest.TestCase):

--- a/tests/test_stuff.py
+++ b/tests/test_stuff.py
@@ -94,6 +94,10 @@ class TestFactParsing(unittest.TestCase):
         assert activity.end_time is None
         assert not activity.category
 
+    def test_description_with_commas(self):
+        activity = Fact.parse("case, meet with a, b and c, #holiday")
+        self.assertEqual(activity.description, "meet with a, b and c")
+
     def test_tags(self):
         # plain activity name
         activity = Fact.parse("#case, description with #hash, #and #some #tägs")

--- a/tests/test_stuff.py
+++ b/tests/test_stuff.py
@@ -129,6 +129,12 @@ class TestFactParsing(unittest.TestCase):
         self.assertEqual(activity.description, "")
         self.assertEqual(set(activity.tags), set(["tag1", "tag2"]))
 
+    def test_tags_with_spaces(self):
+        activity = Fact.parse("case, #tag with space #tag2")
+        self.assertEqual(activity.activity, "case")
+        self.assertEqual(activity.description, "")
+        self.assertEqual(set(activity.tags), set(["tag with space", "tag2"]))
+
     def test_full(self):
         # plain activity name
         activity = Fact.parse(

--- a/tests/test_stuff.py
+++ b/tests/test_stuff.py
@@ -85,7 +85,7 @@ class TestFactParsing(unittest.TestCase):
 
     def test_description(self):
         # plain activity name
-        activity = Fact.parse("case,, with added descriptiön")
+        activity = Fact.parse("case, with added descriptiön")
         self.assertEqual(activity.activity, "case")
         self.assertEqual(activity.description, "with added descriptiön")
         assert not activity.category
@@ -95,7 +95,7 @@ class TestFactParsing(unittest.TestCase):
 
     def test_tags(self):
         # plain activity name
-        activity = Fact.parse("#case,, description with #hash,, #and, #some #tägs")
+        activity = Fact.parse("#case, description with #hash, #and #some #tägs")
         self.assertEqual(activity.activity, "#case")
         self.assertEqual(activity.description, "description with #hash")
         self.assertEqual(set(activity.tags), set(["and", "some", "tägs"]))
@@ -105,16 +105,17 @@ class TestFactParsing(unittest.TestCase):
 
     def test_full(self):
         # plain activity name
-        activity = Fact.parse("1225-1325 case@cat,, description #ta non-tag,, #tag #bäg")
+        activity = Fact.parse(
+            "1225-1325 case@cat, description #hash non-tag, #tag #bäg")
         self.assertEqual(activity.start_time.strftime("%H:%M"), "12:25")
         self.assertEqual(activity.end_time.strftime("%H:%M"), "13:25")
         self.assertEqual(activity.activity, "case")
         self.assertEqual(activity.category, "cat")
-        self.assertEqual(activity.description, "description #ta non-tag")
+        self.assertEqual(activity.description, "description #hash non-tag")
         self.assertEqual(set(activity.tags), set(["bäg", "tag"]))
 
     def test_copy(self):
-        fact1 = Fact.parse("12:25-13:25 case@cat,, description #tag #bäg")
+        fact1 = Fact.parse("12:25-13:25 case@cat, description #tag #bäg")
         fact2 = fact1.copy()
         self.assertEqual(fact1.start_time, fact2.start_time)
         self.assertEqual(fact1.end_time, fact2.end_time)
@@ -132,7 +133,7 @@ class TestFactParsing(unittest.TestCase):
         self.assertEqual(fact3.tags, ["changed"])
 
     def test_comparison(self):
-        fact1 = Fact.parse("12:25-13:25 case@cat,, description #tag #bäg")
+        fact1 = Fact.parse("12:25-13:25 case@cat, description #tag #bäg")
         fact2 = fact1.copy()
         self.assertEqual(fact1, fact2)
         fact2 = fact1.copy()
@@ -161,12 +162,12 @@ class TestFactParsing(unittest.TestCase):
 
     def test_decimal_in_activity(self):
         # cf. issue #270
-        fact = Fact.parse("12:25-13:25 10.0@ABC,, Two Words #tag #bäg")
+        fact = Fact.parse("12:25-13:25 10.0@ABC, Two Words #tag #bäg")
         self.assertEqual(fact.activity, "10.0")
         self.assertEqual(fact.category, "ABC")
         self.assertEqual(fact.description, "Two Words")
         # should not pick up a time here
-        fact = Fact.parse("10.00@ABC,, Two Words #tag #bäg")
+        fact = Fact.parse("10.00@ABC, Two Words #tag #bäg")
         self.assertEqual(fact.activity, "10.00")
         self.assertEqual(fact.category, "ABC")
         self.assertEqual(fact.description, "Two Words")
@@ -186,18 +187,18 @@ class TestFactParsing(unittest.TestCase):
         self.assertEqual(fact3.serialized(), "")
 
     def test_commas(self):
-        fact = Fact.parse("11:00 12:00 activity, with comma@category,, description, with comma")
-        self.assertEqual(fact.activity, "activity, with comma")
+        fact = Fact.parse("11:00 12:00 activity@category, description, with comma")
+        self.assertEqual(fact.activity, "activity")
         self.assertEqual(fact.category, "category")
         self.assertEqual(fact.description, "description, with comma")
         self.assertEqual(fact.tags, [])
-        fact = Fact.parse("11:00 12:00 activity, with comma@category,, description, with comma, #tag1, #tag2")
-        self.assertEqual(fact.activity, "activity, with comma")
+        fact = Fact.parse("11:00 12:00 activity@category, description, with comma, #tag1 #tag2")
+        self.assertEqual(fact.activity, "activity")
         self.assertEqual(fact.category, "category")
         self.assertEqual(fact.description, "description, with comma")
         self.assertEqual(fact.tags, ["tag1", "tag2"])
-        fact = Fact.parse("11:00 12:00 activity, with comma@category,, description, with comma and #hash,, #tag1, #tag2")
-        self.assertEqual(fact.activity, "activity, with comma")
+        fact = Fact.parse("11:00 12:00 activity@category, description, with comma and #hash, #tag1 #tag2")
+        self.assertEqual(fact.activity, "activity")
         self.assertEqual(fact.category, "category")
         self.assertEqual(fact.description, "description, with comma and #hash")
         self.assertEqual(fact.tags, ["tag1", "tag2"])
@@ -215,7 +216,6 @@ class TestFactParsing(unittest.TestCase):
                 for activity in (
                     "activity",
                     "#123 with two #hash",
-                    "activity, with comma",
                     "17.00 tea",
                     ):
                     for category in (
@@ -453,7 +453,7 @@ class TestDatetime(unittest.TestCase):
 
 class TestDBus(unittest.TestCase):
     def test_round_trip(self):
-        fact = Fact.parse("11:00 12:00 activity, with comma@category,, description, with comma #and #tags")
+        fact = Fact.parse("11:00 12:00 activity@category, description, with comma #and #tags")
         dbus_fact = to_dbus_fact_json(fact)
         return_fact = from_dbus_fact_json(dbus_fact)
         self.assertEqual(return_fact, fact)

--- a/tests/test_stuff.py
+++ b/tests/test_stuff.py
@@ -230,6 +230,14 @@ class TestFactParsing(unittest.TestCase):
         self.assertEqual(fact.description, "description, with comma and #hash")
         self.assertEqual(fact.tags, ["hash", "tag1", "tag2"])
 
+    def test_backwards_compat_double_comma(self):
+        fact = Fact.parse("act@cat,, My description,, #tag1 #tag2")
+        self.assertEqual(fact.description, "My description")
+        self.assertEqual(fact.tags, ["tag1", "tag2"])
+        fact = Fact.parse("act@cat,, My description, with comma,, #tag1 #tag2")
+        self.assertEqual(fact.description, "My description, with comma")
+        self.assertEqual(fact.tags, ["tag1", "tag2"])
+
     # ugly. Really need pytest
     def test_roundtrips(self):
         for start_time in (


### PR DESCRIPTION
This PR builds on top #662 to further simplify the parsing facts by creating a clear barrier between the description and the tags. But to be nice with the user, we support a subset of tags within the description that we copy over to the tag list and that we keep as plain words within the description.