### PR TITLE
hamster/client: edit_activity: don't touch self.date on date changes

### DIFF
--- a/src/hamster/edit_activity.py
+++ b/src/hamster/edit_activity.py
@@ -248,7 +248,6 @@ class CustomFactController(Controller):
                     # preserve fact duration
                     self.fact.end_time += delta
                     self.end_date.date = self.fact.end_time
-            self.date = self.fact.date or dt.hday.today()
             self.validate_fields()
             self.update_cmdline()
 


### PR DESCRIPTION
The fact is recalculated already in on_start_date_change(). By calling the setter of
self.date the fact would be change a second time. The start_date was then wrong by
the delta. E.g. edit a complete fact (start and end must be set). Click on the start date and choose 2 days into the future, the command line shows now 4 days into the future.

Fixes: #667