### PR TITLE
Fix time-activity overlap with wide fonts

### DIFF
--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -76,7 +76,7 @@ class Label(object):
         self._label_context = cairo.Context(cairo.ImageSurface(cairo.FORMAT_A1, 0, 0))
         self.layout = pangocairo.create_layout(self._label_context)
         self.layout.set_font_description(pango.FontDescription(graphics._font_desc))
-        self.set_text("Hamster")  # dummy
+        self.set_text("00:00 - 00:00")  # dummy time_label for finding width
 
     @property
     def height(self):
@@ -128,7 +128,8 @@ class TagLabel(Label):
 class FactRow(object):
     def __init__(self):
         self.time_label = Label()
-        self.activity_label = Label(x=100)
+        x = self.time_label.layout.get_pixel_size()[0] + 10
+        self.activity_label = Label(x=x)
 
         self.category_label = Label()
         self.description_label = Label()


### PR DESCRIPTION
Fixes #698. The width alotted to the time interval in the overview was
fixed at 100 pixels but that was not sufficient when using large/wide
fonts. This PR uses the pixel width of ""00:00 - 00:00" when rendered
using the current default font.