### PR TITLE
Fix facttree touchpad scrolling on Wayland by removing custom scroll code

### DIFF
--- a/src/hamster/overview.py
+++ b/src/hamster/overview.py
@@ -559,7 +559,7 @@ class Overview(Controller):
     def on_stop_clicked(self, button):
         self.storage.stop_tracking()
 
-    def on_row_activated(self, tree, day, fact):
+    def on_row_activated(self, tree, fact):
         self.present_fact_controller("edit", fact_id=fact.id)
 
     def on_row_delete_called(self, tree, fact):

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -33,20 +33,6 @@ from hamster.lib import stuff
 from hamster.lib.fact import Fact
 
 
-class ActionRow(graphics.Sprite):
-    def __init__(self):
-        graphics.Sprite.__init__(self)
-        self.visible = False
-
-        self.restart = graphics.Icon("view-refresh-symbolic", size=18,
-                                     interactive=True,
-                                     mouse_cursor=gdk.CursorType.HAND1,
-                                     y=4)
-        self.add_child(self.restart)
-
-        self.width = 50  # Simon says
-
-
 class TotalFact(Fact):
     """An extension of Fact that is used for daily totals.
     Instances of this class are rendered differently than instances
@@ -308,9 +294,6 @@ class FactTree(graphics.Scene, gtk.Scrollable):
 
         self.fact_row = FactRow()
 
-        self.action_row = ActionRow()
-        # self.add_child(self.action_row)
-
         self.row_positions = []
         self.row_heights = []
 
@@ -356,6 +339,7 @@ class FactTree(graphics.Scene, gtk.Scrollable):
             # Totals can't be selected
             elif not isinstance(self.hover_fact, TotalFact):
                 self.set_current_fact(self.hover_fact)
+            self.redraw()
 
     def activate_row(self, day, fact):
         self.emit("on-activate-row", day, fact)
@@ -445,11 +429,6 @@ class FactTree(graphics.Scene, gtk.Scrollable):
                 hover_day = rec
                 break
 
-        if hover_day != self.hover_day:
-            # Facts are considered equal if their content is the same,
-            # even if their id is different.
-            # redraw only cares about content, not id.
-            self.redraw()
         # make sure it is always fully updated, including facts ids.
         self.hover_day = hover_day
 
@@ -459,21 +438,8 @@ class FactTree(graphics.Scene, gtk.Scrollable):
                     hover_fact = fact
                     break
 
-        if (hover_fact
-                and self.hover_fact
-                and hover_fact.id != self.hover_fact.id
-                ):
-            self.move_actions()
         # idem, always update hover_fact, not just if they appear different
         self.hover_fact = hover_fact
-
-    def move_actions(self):
-        if self.hover_fact:
-            self.action_row.visible = True
-            self.action_row.x = self.width - 80 - self.action_row.width
-            self.action_row.y = self.hover_fact.y - self.y
-        else:
-            self.action_row.visible = False
 
     def _on_vadjustment_change(self, scene, vadjustment):
         if not self.vadjustment:
@@ -596,7 +562,6 @@ class FactTree(graphics.Scene, gtk.Scrollable):
             self.vadjustment.set_value(y_pos)
         self.y = y_pos
 
-        self.move_actions()
         self.redraw()
 
         self.visible_range = self.get_visible_range()

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -428,21 +428,18 @@ class FactTree(gtk.DrawingArea, gtk.Scrollable):
                                                                     self.days[start:end]))]
 
     def on_mouse_move(self, widget, event):
-        hover_day, hover_fact = None, None
+        facts = []
+        hover_fact = None
 
-        for rec in self.visible_range:
-            if rec['y'] <= event.y <= (rec['y'] + rec['h']):
-                hover_day = rec
+        y = event.y
+        candidate = bisect.bisect(self.row_positions, y) - 1
+        if candidate >= 0 and y < self.row_positions[candidate] + self.row_heights[candidate]:
+            day, facts = self.days[candidate]
+
+        for fact in facts:
+            if (fact.y - self.y) <= event.y <= (fact.y - self.y + fact.height):
+                hover_fact = fact
                 break
-
-        # make sure it is always fully updated, including facts ids.
-        self.hover_day = hover_day
-
-        if self.hover_day:
-            for fact in self.hover_day.get('facts', []):
-                if (fact.y - self.y) <= event.y <= (fact.y - self.y + fact.height):
-                    hover_fact = fact
-                    break
 
         # idem, always update hover_fact, not just if they appear different
         self.hover_fact = hover_fact

--- a/src/hamster/widgets/facttree.py
+++ b/src/hamster/widgets/facttree.py
@@ -273,7 +273,7 @@ class FactTree(graphics.Scene, gtk.Scrollable):
 
     __gsignals__ = {
         # enter or double-click, passes in current day and fact
-        'on-activate-row': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT, gobject.TYPE_PYOBJECT)),
+        'on-activate-row': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT,)),
         'on-delete-called': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE, (gobject.TYPE_PYOBJECT,)),
     }
 
@@ -341,15 +341,15 @@ class FactTree(graphics.Scene, gtk.Scrollable):
                 self.set_current_fact(self.hover_fact)
             self.redraw()
 
-    def activate_row(self, day, fact):
-        self.emit("on-activate-row", day, fact)
+    def activate_row(self, fact):
+        self.emit("on-activate-row", fact)
 
     def delete_row(self, fact):
         self.emit("on-delete-called", fact)
 
     def on_double_click(self, scene, event):
         if self.hover_fact and not isinstance(self.hover_fact, TotalFact):
-            self.activate_row(self.hover_day, self.hover_fact)
+            self.activate_row(self.hover_fact)
 
     def on_key_press(self, scene, event):
         # all keys should appear also in the Overview.on_key_press
@@ -390,7 +390,7 @@ class FactTree(graphics.Scene, gtk.Scrollable):
 
         elif event.keyval == gdk.KEY_Return:
             if self.current_fact:
-                self.activate_row(self.hover_day, self.current_fact)
+                self.activate_row(self.current_fact)
 
         elif event.keyval == gdk.KEY_Delete:
             if self.current_fact:


### PR DESCRIPTION
This PR was prompted by touchpad scrolling not working on wayland, because this is handled using different ("smooth") scroll events that were not handled by the custom scrolling code.

This is fixed by removing all the custom scrolling code, making the facttree DrawingArea just big enough to fit all facts and just letting gtk handle scrolling by moving the facttree inside a viewport. By only redrawing dirty areas, invisible facts are (still) not drawn (and it seems that when scrolling, there is now less need to redraw previously drawn areas as well).

Leading up to this change are a few more commits with additional cleanups, mostly removing unused code or small refactorings that make the main change easier to implement.

There might be subtle changes (i.e. in how far things are scrolled when pressing pgdown), but there should be nothing that is actually significant.

Tested on Wayland and Xorg (both inside Gnome), seems to work as expected.