### PR TITLE
Add python3-gi-cairo as a dependency in the README

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,7 +38,7 @@ jobs:
           # Install a specific python version as configured
           PACKAGES="$PACKAGES python${{matrix.python-version}}"
           # Normal dependencies
-          PACKAGES="$PACKAGES gettext intltool python3-gi python3-cairo python3-dbus python3-xdg libglib2.0-dev libglib2.0-bin gir1.2-gtk-3.0 gtk-update-icon-cache python3-distutils"
+          PACKAGES="$PACKAGES gettext intltool python3-gi python3-cairo python3-gi-cairo python3-distutils python3-dbus python3-xdg libglib2.0-dev libglib2.0-bin gir1.2-gtk-3.0 gtk-update-icon-cache"
           # For dbus-launch
           PACKAGES="$PACKAGES dbus-x11"
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ commands). Older versions are not supported.
 ###### Ubuntu (tested in 19.04 and 18.04)
 
 ```bash
-sudo apt install gettext intltool python3-gi python3-cairo python3-distutils python3-dbus python3-xdg libglib2.0-dev libglib2.0-bin gir1.2-gtk-3.0 gtk-update-icon-cache
+sudo apt install gettext intltool python3-gi python3-cairo python3-gi-cairo python3-distutils python3-dbus python3-xdg libglib2.0-dev libglib2.0-bin gir1.2-gtk-3.0 gtk-update-icon-cache
 # and for documentation
 sudo apt install itstool yelp
 ```


### PR DESCRIPTION
(Should also be added to the packaging system, but I don't know how that works.)