### PR TITLE
Update i18n.py

### DIFF
--- a/src/hamster/lib/i18n.py
+++ b/src/hamster/lib/i18n.py
@@ -21,7 +21,7 @@ def setup_i18n():
             module.bindtextdomain('hamster', locale_dir)
             module.textdomain('hamster')
 
-            module.bind_textdomain_codeset('hamster','utf8')
+#            module.bind_textdomain_codeset('hamster','utf8')
 
         gettext.install("hamster", locale_dir)
 


### PR DESCRIPTION
Fix for python 3.11 - module.bind_textdomain_codeset was removed