### PR TITLE
Remove call to deprecated bind_textdomain_codeset gettext function

### DIFF
--- a/src/hamster/lib/i18n.py
+++ b/src/hamster/lib/i18n.py
@@ -21,8 +21,6 @@ def setup_i18n():
             module.bindtextdomain('hamster', locale_dir)
             module.textdomain('hamster')
 
-            module.bind_textdomain_codeset('hamster','utf8')
-
         gettext.install("hamster", locale_dir)
 
     else:


### PR DESCRIPTION
This function was deprecated and eventually removed in Python3.11 (see changelog at https://docs.python.org/3/whatsnew/3.11.html)

> Removed the deprecated gettext functions lgettext(), ldgettext(),
> lngettext() and ldngettext(). Also removed the bind_textdomain_codeset()
> function, the NullTranslations.output_charset() and
> NullTranslations.set_output_charset() methods, and the codeset parameter
> of translation() and install(), since they are only used for the
> l*gettext() functions. (Contributed by Dong-hee Na and Serhiy Storchaka
> in bpo-44235.)

Fixes #714 