### PR TITLE
Use ubuntu 20.04 for workflows

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,10 +16,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Test 3.6, which is our minimum version, on 18.04 since the
-          # latest Ubuntu does not have it.
-          - os: ubuntu-18.04
-            python-version: 3.6
+          # This tests uses the oldest Ubuntu and its oldest Python
+          # version, to get as close to our minimum required version as
+          # possible. This does mean that we will not catch changes to
+          # the code that unintentionally reaise the required python
+          # version, but there's no easy way to run an older python
+          # version (without having to install all or dependencies from
+          # source) it seems.
+          - os: ubuntu-20.04
+            python-version: 3.8
           # On the latest ubuntu, just test the default 3.x version.
           - os: ubuntu-latest
             python-version: 3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -54,7 +54,7 @@ jobs:
 
   flake8:
     name: Run code linting and checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Prepare repo
         uses: actions/checkout@v2

--- a/src/hamster/lib/pytweener.py
+++ b/src/hamster/lib/pytweener.py
@@ -314,7 +314,7 @@ class Easing(object):
 
 
     def _elastic_in(t, springiness = 0, wave_length = 0):
-        if t in(0, 1):
+        if t in (0, 1):
             return t
 
         wave_length = wave_length or (1 - t) * 0.3


### PR DESCRIPTION
This fixes the flake8 workflow (which failed due to missing python 3.5 on ubuntu-latest) and fixes the test suite on python3.5 (due to no longer supported explicitly configured ubuntu-18.04). See commit messages for a bit more details.

Note that that with this change, we could also consider lowering the required python version from 3.6 back to 3.5 (it was only raised by @tchernobog in #685 in the assumption that ubuntu-18.04 did not have 3.5, but looking at the [python-versions](https://github.com/actions/python-versions/blob/main/versions-manifest.json) repo, which is used by the [setup-python action](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#available-versions-of-python-and-pypy), I believe it *is* actually available), but since python 3.6 is pretty well available (even Debian oldstable buster has 3.7), I guess it is fine to leave it at 3.6.