### PR TITLE
flatpak: Update gnome platform

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install GNOME SDK for flatpak
         run: |
           flatpak remote-add --user --if-not-exists --from flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install --user -y flathub org.gnome.Platform//41 org.gnome.Sdk//41
+          flatpak install --user -y flathub org.gnome.Platform//45 org.gnome.Sdk//45
       - name: Build application
         run: |
           flatpak-builder --repo=build/flatpak/repo build/flatpak/tmp org.gnome.Hamster.yml

--- a/org.gnome.Hamster.yml
+++ b/org.gnome.Hamster.yml
@@ -1,7 +1,7 @@
 ---
 app-id: org.gnome.Hamster
 runtime: org.gnome.Platform
-runtime-version: '41'
+runtime-version: '45'
 sdk: org.gnome.Sdk
 command: hamster
 modules:


### PR DESCRIPTION
The previously used version 41 has been unsupported since 2022, so update it.

This does not update dbus-python yet, since the 1.3.0 version requires meson as a build system, but seems to require a newer version than what the gnome/freedesktop 45 SDK supports and manually installing a newer version takes more effort with no signficant gains, see also https://github.com/flathub/net.lutris.Lutris/blob/7bd51222b8076abd8fcbfe9cb0e4d6e70bafca24/net.lutris.Lutris.yml#L775-L780