### PR TITLE
Require whitespace before tags in description field

### DIFF
--- a/src/hamster/lib/parsing.py
+++ b/src/hamster/lib/parsing.py
@@ -19,6 +19,7 @@ tag_re = re.compile(r"""
 """, flags=re.VERBOSE)
 
 tags_in_description = re.compile(r"""
+    \s
     \#
     (?P<tag>
         [a-zA-Z] # Starts with an alphabetic character (digits excluded)


### PR DESCRIPTION
As of v3.0.3 hamster harvests single word #hash tags from the description field. This PR tweaks the regex used to extract the tags, requiring whitespace before the # character. This will prevent harvesting a tag from a pattern like example.com/page#anchor, as mentioned here: https://github.com/projecthamster/hamster/issues/753#issuecomment-1884597243.

This does not affect any of the test cases in test_stuff.py nor the examples from the input.page documentation.