### PR TITLE
Remove dependency on deprecated distutils package.

### DIFF
--- a/src/hamster/client.py
+++ b/src/hamster/client.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)   # noqa: E402
 import sys
 
 from calendar import timegm
-from distutils.version import LooseVersion
+import packaging.version as pv
 from gi.repository import GObject as gobject
 from textwrap import dedent
 
@@ -45,7 +45,7 @@ from hamster.lib import datetime as dt
 # bug fixed in dbus-python 1.2.14 (released on 2019-11-25)
 assert not (
     sys.version_info >= (3, 8)
-    and LooseVersion(dbus.__version__) < LooseVersion("1.2.14")
+    and pv.parse(dbus.__version__) < pv.Version("1.2.14")
     ), """python3.8 changed str(<dbus integers>).
        That broke hamster (https://github.com/projecthamster/hamster/issues/477).
        Please upgrade to dbus-python >= 1.2.14.


### PR DESCRIPTION
As of Python 3.10 the distutils package has been deprecated and it will be removed from Python 3.12. This PR uses alternative functions from the packaging.versions submodule.