### PR TITLE
Remove old window presentation workaround that causes timstamp overflows

### DIFF
--- a/src/hamster/lib/configuration.py
+++ b/src/hamster/lib/configuration.py
@@ -74,10 +74,7 @@ class Controller(gobject.GObject):
 
     def present(self):
         """Show window and bring it to the foreground."""
-        # workaround https://gitlab.gnome.org/GNOME/gtk/issues/624
-        # fixed in gtk-3.24.1 (2018-09-19)
-        # self.overview_controller.window.present()
-        self.window.present_with_time(glib.get_monotonic_time() / 1000)
+        self.window.present()
 
     def show(self):
         """Show window.


### PR DESCRIPTION
On systems with an uptime of > 49 days (32bit overflow of millisecond counters), I get warnings like this:

```
Traceback (most recent call last):
  File "/home/chrysn/git/hamster/./src/hamster-cli.py", line 149, in on_activate_window
    self._open_window(action.get_name(), data)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/chrysn/git/hamster/./src/hamster-cli.py", line 209, in _open_window
    controller.present()
    ~~~~~~~~~~~~~~~~~~^^
  File "/home/chrysn/git/hamster/src/hamster/lib/configuration.py", line 80, in present
    self.window.present_with_time(glib.get_monotonic_time() / 1000)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OverflowError: 5068768155 not in range 0 to 4294967295
```

While they have no observable impact, somewhere down there things do go wrong.

Tracing through the code, this was a workaround for GTK 3.24.1 -- I'd claim that this was so long ago that nobody is using it any more, but the oldest version I could easily date through Debian was 3.24.24 (bullseye, 2021) and 3.24.32 (Ubuntu Jammy, 2022 LTS), and old changelog entries were purged from Debian packages in 2019 when it was at 3.24.10, so yeah it's really ancient.

(Before I looked up the version, I tried for workarounds `self.window.present_with_time(gdk.CURRENT_TIME)` and `self.window.present_with_time((glib.get_monotonic_time() // 1000) & 0xffffffff)`, which also worked, but really, I don't think we'll find anyone who can reproduce what this was a workaround for without serious archeology).